### PR TITLE
remove useless option to provision

### DIFF
--- a/manifests/dc.pp
+++ b/manifests/dc.pp
@@ -173,7 +173,7 @@ ex: domain="ad" and realm="ad.example.com"')
     command => "printf '' > '${::samba::params::smbconffile}' && \
 ${::samba::params::sambacmd} domain provision ${hostip} \
 --domain='${domain}' --realm='${realm}' --dns-backend='${sambadns}' \
---targetdir='${targetdir}' --workgroup='${domain}' --use-rfc2307 \
+--targetdir='${targetdir}' --use-rfc2307 \
 --configfile='${::samba::params::smbconffile}' --server-role='${role}' -d 1 && \
 mv '${targetdir}/etc/smb.conf' '${::samba::params::smbconffile}'",
     require => Package['SambaDC'],


### PR DESCRIPTION
"because it was always useless" not needed for the provision tool in any version, so just removed it here.  Fixes issue #2

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/5)

<!-- Reviewable:end -->
