### PR TITLE
add a space between options in domain passwordsettings command

### DIFF
--- a/manifests/dc/ppolicy.pp
+++ b/manifests/dc/ppolicy.pp
@@ -40,14 +40,14 @@ class samba::dc::ppolicy (
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',
     require => Service['SambaDC'],
     unless  => "\
-[ \"\$( ${::samba::params::sambacmd} domain passwordsettings show -d 1\
+[ \"\$( ${::samba::params::sambacmd} domain passwordsettings show -d 1 \
 |sed 's/^.*:\\ *\\([0-9]\\+\\|on\\|off\\).*$/\\1/gp;d' | md5sum )\" = \
 \"\$(printf \
 '${ppolicycomplexity}\\n${ppolicyplaintext}\\n${ppolicyhistorylength}\
 \\n${ppolicyminpwdlength}\\n${ppolicyminpwdage}\\n${ppolicymaxpwdage}\\n' \
 | md5sum )\" ]",
 
-    command => "${::samba::params::sambacmd} domain passwordsettings set -d 1\
+    command => "${::samba::params::sambacmd} domain passwordsettings set -d 1 \
 --complexity='${ppolicycomplexity}' \
 --store-plaintext='${ppolicyplaintext}' \
 --history-length='${ppolicyhistorylength}' \


### PR DESCRIPTION
fixes #3 

I did test this :)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/6)

<!-- Reviewable:end -->
