### PR TITLE
add param $manage_directory to allow multiple shares to use the same directory

### DIFF
--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -44,6 +44,7 @@ define samba::share(
   $group = 'root',
   $mode  = '0777',
   $acl   = undef,
+  $manage_directory = true,
 ) {
 
   if defined(Package['SambaClassic']){
@@ -60,12 +61,14 @@ define samba::share(
     $rootpath = regsubst($path, '(^[^%]*/)[^%]*%.*', '\1')
     validate_absolute_path($rootpath)
 
-    ::samba::dir {$rootpath:
-      path  => $rootpath,
-      owner => $owner,
-      group => $group,
-      mode  => $mode,
-      acl   => $acl,
+    if $manage_directory {
+      ::samba::dir {$rootpath:
+        path  => $rootpath,
+        owner => $owner,
+        group => $group,
+        mode  => $mode,
+        acl   => $acl,
+      }
     }
 
     smb_setting { "${name}/path":


### PR DESCRIPTION
The module does a good job by taking care that all share directories actually exist. Unfortunately, if you need to use the _same_ directory for _multiple_ shares this leads to duplicate declarations:

```
Error: Failed to apply catalog: Cannot alias File[/var/spool/samba/] to ["/var/spool/samba"] at /etc/puppet/environments/development/modules/samba/manifests/dir.pp:66; resource ["File", "/var/spool/samba"] already declared at /etc/puppet/environments/development/modules/samba/manifests/dir.pp:66
```

A common use-case are [samba printer shares](https://wiki.samba.org/index.php/Setup_a_Samba_print_server). All printer shares point to the same spool directory, but you need to setup a separate share for every printer.

With the patch it is possible to disable the auto-creation of share directories:

```
::samba::share { 'printers':
  path   => '/var/spool/samba',
  mode   => '1775',
}
::samba::share { 'MyPrinter_1':
  path             => '/var/spool/samba',
  manage_directory => false
}
::samba::share { 'MyPrinter_2':
  path             => '/var/spool/samba',
  manage_directory => false
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/10)

<!-- Reviewable:end -->
