### PR TITLE
Optional realm check

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ class { '::samba::classic':
   # Mandatory parameters
   domain                => 'DC',          # * Domain to authentify against
   realm                 => 'dc.kakwa.fr', # * Realm to authentify against
+  strictrealm           => true,          # * Check for Strict Realm
   smbname               => 'SMB',         # * Share name
   sambaloglevel         => 3,             # * Samba log level
   logtosyslog           => true,          # * Log to Syslog

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -66,11 +66,10 @@ class samba::classic(
     fail('smbname must be a valid domain')
   }
 
-  $tmparr = split($realm, '[.]')
-  unless $domain == $tmparr[0] {
-    fail('domain must be the fist part of realm, \
-ex: domain="ad" and realm="ad.example.com"')
-  }
+  #$tmparr = split($realm, '[.]')
+  #unless $domain == $tmparr[0] {
+  #  fail('domain must be the fist part of realm, ex: domain="ad" and realm="ad.example.com"')
+  #}
 
   $checksecurity = ['ads', 'auto', 'user', 'domain']
   $checksecuritystr = join($checksecurity, ', ')

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -40,6 +40,7 @@ class samba::classic(
   $smbname              = undef,
   $domain               = undef,
   $realm                = undef,
+  $strictrealm          = true,
   $adminuser            = 'administrator',
   $adminpassword        = undef,
   $security             = 'ads',
@@ -66,10 +67,12 @@ class samba::classic(
     fail('smbname must be a valid domain')
   }
 
-  #$tmparr = split($realm, '[.]')
-  #unless $domain == $tmparr[0] {
-  #  fail('domain must be the fist part of realm, ex: domain="ad" and realm="ad.example.com"')
-  #}
+  if $strictrealm {
+    $tmparr = split($realm, '[.]')
+    unless $domain == $tmparr[0] {
+      fail('domain must be the fist part of realm, ex: domain="ad" and realm="ad.example.com"')
+    }
+  }
 
   $checksecurity = ['ads', 'auto', 'user', 'domain']
   $checksecuritystr = join($checksecurity, ', ')


### PR DESCRIPTION
Due to history reasons the realm check fails in our domain. The netbios name and dns name are completely independent in our case, so I made a switch to turn it off.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/12)

<!-- Reviewable:end -->
