### PR TITLE
fix Could not autoload puppet/type/smb_acl error

### DIFF
--- a/lib/puppet/provider/smb_acl/posixacl.rb
+++ b/lib/puppet/provider/smb_acl/posixacl.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), '..', 'acl')
+require File.join(File.dirname(__FILE__), '..', 'smb_acl')
 
 Puppet::Type.type(:smb_acl).provide(:posixacl, :parent => Puppet::Provider::Smb_Acl) do
   desc "Provide posix 1e acl functions using posix getfacl/setfacl commands"


### PR DESCRIPTION
This commit fixes the following error :
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not autoload puppet/type/smb_acl: Could not autoload puppet/provider/smb_acl/posixacl: cannot load such file -- /etc/puppet/environments/production/modules/samba/lib/puppet/provider/smb_acl/../acl on node giptaaq-qc-dev.openstacklocal
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/13)

<!-- Reviewable:end -->
