### PR TITLE
type cast strings to integers for puppet 4

### DIFF
--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -8,8 +8,8 @@ define samba::log(
 ) {
 
   unless is_integer($sambaloglevel)
-    and $sambaloglevel >= 0
-    and $sambaloglevel <= 10{
+    and ($sambaloglevel + 0) >= 0
+    and ($sambaloglevel + 0) <= 10{
     fail('loglevel must be an integer between 0 and 10')
   }
 


### PR DESCRIPTION
This fixes a bug you'll be seing if you enable the future parser or by switching to Puppet 4.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/16)

<!-- Reviewable:end -->
