### PR TITLE
Debian updated samba and the service is now smbd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,8 @@ class samba::params(
           $servivesambadc      = 'samba-ad-dc'
         if $::operatingsystem == 'Ubuntu' {
           $servivesmb          = 'smbd'
+        } elsif ($::operatingsystem == 'Debian') and ($::operatingsystemmajrelease >= '8') {
+          $servivesmb          = 'smbd'
         } else {
           $servivesmb          = 'samba'
         }


### PR DESCRIPTION
Debian updated samba and the service is now smbd (Debian 8 >)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/20)

<!-- Reviewable:end -->
