### PR TITLE
Fixed incorrect variable names in templates

### DIFF
--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -9,15 +9,15 @@
  renew_lifetime = 7d
  forwardable = true
  rdns = false
- default_realm = <%= realmuppercase %>
+ default_realm = <%= @realmuppercase %>
  default_ccache_name = KEYRING:persistent:%{uid}
 
 [realms]
- <%= realmuppercase %> = {
-  kdc = <%= realmlowercase %>
-  admin_server = <%= realmlowercase %>
+ <%= @realmuppercase %> = {
+  kdc = <%= @realmlowercase %>
+  admin_server = <%= @realmlowercase %>
  }
 
 [domain_realm]
- .<%= realmlowercase %> = <%= realmuppercase %>
- <%= realmlowercase %> = <%= realmuppercase %>
+ .<%= @realmlowercase %> = <%= @realmuppercase %>
+ <%= @realmlowercase %> = <%= @realmuppercase %>

--- a/templates/sernet-samba.erb
+++ b/templates/sernet-samba.erb
@@ -4,7 +4,7 @@
 #   "ad"      to use the Active Directory server (which starts the smbd on its own)
 # (Be aware that you also need to enable the services/init scripts that
 # automatically start up the desired daemons.)
-SAMBA_START_MODE="<%= sambamode %>"
+SAMBA_START_MODE="<%= @sambamode %>"
 
 # SAMBA_RESTART_ON_UPDATE defines if the the services should be restarted when
 # the RPMs are updated. Setting this to "yes" effectively enables the


### PR DESCRIPTION
This is referring to issue #21 - https://github.com/kakwa/puppet-samba/issues/21
These changes to the templates properly insert the variables into the created files and remove the error message received.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/22)

<!-- Reviewable:end -->
