### PR TITLE
Additional trigger flags for samba::classic

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -45,6 +45,8 @@ class samba::classic(
   $adminpassword        = undef,
   $security             = 'ads',
   $sambaloglevel        = 1,
+  $join_domain          = false,
+  $manage_winbind       = false,
   $krbconf              = true,
   $nsswitch             = true,
   $sambaclassloglevel   = undef,
@@ -96,48 +98,52 @@ class samba::classic(
     require => File['/etc/samba/'],
   }
 
-  if $krbconf {
-    file {$::samba::params::krbconffile:
-      ensure  => present,
-      mode    => '0644',
-      content => template("${module_name}/krb5.conf.erb"),
-      notify  => Service['SambaSmb', 'SambaWinBind'],
+  if $join_domain {
+    if $krbconf {
+      file {$::samba::params::krbconffile:
+        ensure  => present,
+        mode    => '0644',
+        content => template("${module_name}/krb5.conf.erb"),
+        notify  => Service['SambaSmb', 'SambaWinBind'],
+      }
+    }
+  
+    if $nsswitch {
+      augeas{'samba nsswitch group':
+        context => "/files/${::samba::params::nsswitchconffile}/",
+        changes => [
+          'ins service after "*[self::database = \'group\']/service[1]/"',
+          'set "*[self::database = \'group\']/service[2]" winbind',
+        ],
+        onlyif  => 'get "*[self::database = \'group\']/service[2]" != winbind',
+        lens    => 'Nsswitch.lns',
+        incl    => $::samba::params::nsswitchconffile,
+      }
+      augeas{'samba nsswitch passwd':
+        context => "/files/${::samba::params::nsswitchconffile}/",
+        changes => [
+          'ins service after "*[self::database = \'passwd\']/service[1]/"',
+          'set "*[self::database = \'passwd\']/service[2]" winbind',
+        ],
+        onlyif  => 'get "*[self::database = \'passwd\']/service[2]" != winbind',
+        lens    => 'Nsswitch.lns',
+        incl    => $::samba::params::nsswitchconffile,
+      }
     }
   }
 
-  if $nsswitch {
-    augeas{'samba nsswitch group':
-      context => "/files/${::samba::params::nsswitchconffile}/",
-      changes => [
-        'ins service after "*[self::database = \'group\']/service[1]/"',
-        'set "*[self::database = \'group\']/service[2]" winbind',
-      ],
-      onlyif  => 'get "*[self::database = \'group\']/service[2]" != winbind',
-      lens    => 'Nsswitch.lns',
-      incl    => $::samba::params::nsswitchconffile,
+  if $manage_winbind {
+    package{ 'SambaClassicWinBind':
+      ensure  => 'installed',
+      name    => $::samba::params::packagesambawinbind,
+      require => File['/etc/samba/smb_path'],
     }
-    augeas{'samba nsswitch passwd':
-      context => "/files/${::samba::params::nsswitchconffile}/",
-      changes => [
-        'ins service after "*[self::database = \'passwd\']/service[1]/"',
-        'set "*[self::database = \'passwd\']/service[2]" winbind',
-      ],
-      onlyif  => 'get "*[self::database = \'passwd\']/service[2]" != winbind',
-      lens    => 'Nsswitch.lns',
-      incl    => $::samba::params::nsswitchconffile,
-    }
-  }
-
-  package{ 'SambaClassicWinBind':
-    ensure  => 'installed',
-    name    => $::samba::params::packagesambawinbind,
-    require => File['/etc/samba/smb_path'],
   }
 
   package{ 'SambaClassic':
     ensure  => 'installed',
     name    => $::samba::params::packagesambaclassic,
-    require => Package['SambaClassicWinBind'],
+    require => $manage_winbind ? Package['SambaClassicWinBind'] : '',
   }
 
   service{ 'SambaSmb':
@@ -160,23 +166,38 @@ class samba::classic(
     require => Package['SambaClassic'],
   }
 
-  $mandatoryglobaloptions = {
-    'workgroup'                          => $domain,
-    'realm'                              => $realm,
-    'netbios name'                       => $smbname,
-    'security'                           => $security,
-    'dedicated keytab file'              => '/etc/krb5.keytab',
-    'vfs objects'                        => 'acl_xattr',
-    'map acl inherit'                    => 'Yes',
-    'store dos attributes'               => 'Yes',
-    'map untrusted to domain'            => 'Yes',
-    'winbind nss info'                   => 'rfc2307',
-    'winbind trusted domains only'       => 'No',
-    'winbind use default domain'         => 'Yes',
-    'winbind enum users'                 => 'Yes',
-    'winbind enum groups'                => 'Yes',
-    'winbind refresh tickets'            => 'Yes',
-    'winbind separator'                  => '+',
+  if $manage_winbind {
+    $mandatoryglobaloptions = {
+      'workgroup'                          => $domain,
+      'realm'                              => $realm,
+      'netbios name'                       => $smbname,
+      'security'                           => $security,
+      'dedicated keytab file'              => '/etc/krb5.keytab',
+      'vfs objects'                        => 'acl_xattr',
+      'map acl inherit'                    => 'Yes',
+      'store dos attributes'               => 'Yes',
+      'map untrusted to domain'            => 'Yes',
+      'winbind nss info'                   => 'rfc2307',
+      'winbind trusted domains only'       => 'No',
+      'winbind use default domain'         => 'Yes',
+      'winbind enum users'                 => 'Yes',
+      'winbind enum groups'                => 'Yes',
+      'winbind refresh tickets'            => 'Yes',
+      'winbind separator'                  => '+',
+    }
+  }
+  else {
+    $mandatoryglobaloptions = {
+      'workgroup'                          => $domain,
+      'realm'                              => $realm,
+      'netbios name'                       => $smbname,
+      'security'                           => $security,
+      'vfs objects'                        => 'acl_xattr',
+      'dedicated keytab file'              => '/etc/krb5.keytab',
+      'map acl inherit'                    => 'Yes',
+      'store dos attributes'               => 'Yes',
+      'map untrusted to domain'            => 'Yes',
+    }
   }
 
   file{ 'SambaCreateHome':
@@ -187,12 +208,19 @@ class samba::classic(
 
   $mandatoryglobaloptionsindex = prefix(keys($mandatoryglobaloptions),
     '[global]')
+
+  if $manage_winbind {
+    $services_to_notify = ['SambaSmb', 'SambaWinBind'
+  }
+  else {
+    $services_to_notify = ['SambaSmb']
+  }
   ::samba::option{ $mandatoryglobaloptionsindex:
     options         => $mandatoryglobaloptions,
     section         => 'global',
     settingsignored => $globaloptsexclude,
     require         => Package['SambaClassic'],
-    notify          => Service['SambaSmb', 'SambaWinBind'],
+    notify          => Service[$services_to_notify],
   }
 
   ::samba::log { 'syslog':
@@ -201,7 +229,7 @@ class samba::classic(
     sambaclassloglevel => $sambaclassloglevel,
     settingsignored    => $globaloptsexclude,
     require            => Package['SambaClassic'],
-    notify             => Service['SambaSmb', 'SambaWinBind'],
+    notify             => Service[$services_to_notify],
   }
 
   # Iteration on global options
@@ -210,7 +238,7 @@ class samba::classic(
     options => $globaloptions,
     section => 'global',
     require => Package['SambaClassic'],
-    notify  => Service['SambaSmb', 'SambaWinBind'],
+    notify  => Service[$services_to_notify],
   }
 
   resources { 'smb_setting':
@@ -222,20 +250,22 @@ class samba::classic(
     ensure  => absent,
     section => 'global',
     require => Package['SambaClassic'],
-    notify  => Service['SambaSmb', 'SambaWinBind'],
+    notify  => Service[$services_to_notify],
   }
 
-  unless $adminpassword == undef {
-    $ou = $joinou ? {
-      default => "createcomputer=\"${joinou}\"",
-      undef   => '',
-    }
-    exec{ 'Join Domain':
-      path    => '/bin:/sbin:/usr/sbin:/usr/bin/',
-      unless  => 'net ads testjoin',
-      command => "echo '${adminpassword}'| net ads join -U '${adminuser}' ${ou}",
-      notify  => Service['SambaWinBind'],
-      require => [ Package['SambaClassic'], Service['SambaSmb'] ],
+  if $manage_winbind and $join_domain {
+    unless $adminpassword == undef {
+      $ou = $joinou ? {
+        default => "createcomputer=\"${joinou}\"",
+        undef   => '',
+      }
+      exec{ 'Join Domain':
+        path    => '/bin:/sbin:/usr/sbin:/usr/bin/',
+        unless  => 'net ads testjoin',
+        command => "echo '${adminpassword}'| net ads join -U '${adminuser}' ${ou}",
+        notify  => Service['SambaWinBind'],
+        require => [ Package['SambaClassic'], Service['SambaSmb'] ],
+      }
     }
   }
 }


### PR DESCRIPTION
This PR introduces two additional flags (join_domain and manage_winbind) where the user is able to override the behaviour of the samba::classic class. This is needed if domainjoin is handled by other puppet modules/software projects. In my case i'm using realmd to handle the connection to MS AD and don't use winbind at all.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/23)

<!-- Reviewable:end -->
