### PR TITLE
Require SambaWinBind service to be defined if not managed by this module

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -56,6 +56,9 @@ class samba::classic(
   $joinou               = undef,
 ) inherits ::samba::params{
 
+  if ( !$manage_winbind ) and ( !defined(Service['SambaWinBind']) ) {
+    fail('must provide SambaWinBind service if manage_winbind == false')
+  }
 
   unless is_domain_name($realm){
     fail('realm must be a valid domain')


### PR DESCRIPTION
See #26

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/27)

<!-- Reviewable:end -->
