### PR TITLE
Configure additional REALMS in krb5.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,17 @@ Note that configuring a '\*' domain seems necessary for Idmap to properly work.
 }
 ```
 
+### Multiple Realms
+
+```
+class { '::samba::classic':
+  default_realm => 'FOREST.EXAMPLE.COM'
+  additional_realms => [
+    'FOREST.EXAMPLE.COM'
+  ]
+}
+```
+
 ### Samba Shares
 
 #### Shares

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -54,6 +54,8 @@ class samba::classic(
   $globaloptions        = {},
   $globalabsentoptions  = [],
   $joinou               = undef,
+  $default_realm        = undef,
+  $additional_realms    = [],
 ) inherits ::samba::params{
 
 
@@ -84,9 +86,21 @@ class samba::classic(
     fail("role must be in [${checksecuritystr}]")
   }
 
+  if $additional_realms {
+    validate_array($additional_realms)
+  }
+
+  if $default_realm {
+    validate_string($default_realm)
+  }
+
+
   $realmlowercase = downcase($realm)
   $realmuppercase = upcase($realm)
   $globaloptsexclude = concat(keys($globaloptions), $globalabsentoptions)
+
+  $_default_realm = pick($default_realm, $realmuppercase)
+
 
   file { '/etc/samba/':
     ensure  => 'directory',

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -9,7 +9,7 @@
  renew_lifetime = 7d
  forwardable = true
  rdns = false
- default_realm = <%= @realmuppercase %>
+ default_realm = <%= @_default_realm %>
  default_ccache_name = KEYRING:persistent:%{uid}
 
 [realms]
@@ -18,6 +18,17 @@
   admin_server = <%= @realmlowercase %>
  }
 
+<% @additional_realms.each do |realm| -%>
+ <%= realm.upcase %> = {
+  kdc = <%= realm.downcase %>
+  admin_server = <%= realm.downcase %>
+ }
+
+<% end -%>
 [domain_realm]
  .<%= @realmlowercase %> = <%= @realmuppercase %>
  <%= @realmlowercase %> = <%= @realmuppercase %>
+<% @additional_realms.each do |realm| -%>
+ .<%= realm.downcase %> = <%= realm.upcase %>
+ <%= realm.downcase %> = <%= realm.upcase %>
+<% end -%>


### PR DESCRIPTION
If we want query users from a forest domain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/28)
<!-- Reviewable:end -->
