### PR TITLE
Fixes error related to ruby 1.8

### DIFF
--- a/templates/log.erb
+++ b/templates/log.erb
@@ -1,6 +1,6 @@
-<% @sambaclassloglevel.each do |logclass, level| -%>
-<% if not level.to_i.between?(0, 10) -%>
-<%   raise(Puppet::Error, "wrong log level for #{logclass}, must be between 0 and 10") -%>
+<% @sambaclassloglevel.keys.sort.each do |key| -%>
+<% if not @sambaclassloglevel[key].to_i.between?(0, 10) -%>
+<%   raise(Puppet::Error, "wrong log level for #{key}, must be between 0 and 10") -%>
 <% end -%>
- <%= logclass %>:<%= level -%>
+ <%= key %>:<%= @sambaclassloglevel[key] -%>
 <% end -%>


### PR DESCRIPTION
in ruby 1.8 elements of hashes aren't ordered. This causes puppet catalogs to be nondeterministic and therefor changes are made even when source data has not changed. Sorting the hash fixes this. In newer ruby versions this behaviour is fixed and hashes are ordered by insertion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/29)
<!-- Reviewable:end -->
