### PR TITLE
libnss-winbind (Ubuntu/Debian/Redhat)

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -123,6 +123,11 @@ class samba::classic(
     }
 
     if $nsswitch {
+      package{ 'SambaNssWinbind':
+        ensure => 'installed',
+        name   => $::samba::params::packagesambansswinbind
+      }
+
       augeas{'samba nsswitch group':
         context => "/files/${::samba::params::nsswitchconffile}/",
         changes => [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,36 +9,38 @@ class samba::params(
   if $sernetpkgs {
     case $::osfamily {
       'redhat': {
-          $packagesambadc      = 'sernet-samba-ad'
-          $packagesambaclassic = 'sernet-samba'
-          $packagesambaclient  = 'sernet-samba-client'
-          $packagesambawinbind = 'sernet-samba-winbind'
-          $servivesambadc      = 'sernet-samba-ad'
-          $servivesmb          = 'sernet-samba-smbd'
-          $servivewinbind      = 'sernet-samba-winbindd'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/default/sernet-samba'
-          $sambaoptstmpl       = "${module_name}/sernet-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'PyYAML'
+          $packagesambadc         = 'sernet-samba-ad'
+          $packagesambaclassic    = 'sernet-samba'
+          $packagesambaclient     = 'sernet-samba-client'
+          $packagesambawinbind    = 'sernet-samba-winbind'
+          $packagesambansswinbind = 'sernet-samba-libs'
+          $servivesambadc         = 'sernet-samba-ad'
+          $servivesmb             = 'sernet-samba-smbd'
+          $servivewinbind         = 'sernet-samba-winbindd'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/default/sernet-samba'
+          $sambaoptstmpl          = "${module_name}/sernet-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'PyYAML'
       }
       'Debian': {
-          $packagesambadc      = 'sernet-samba-ad'
-          $packagesambaclassic = 'sernet-samba'
-          $packagesambaclient  = 'sernet-samba-client'
-          $packagesambawinbind = 'sernet-samba-winbind'
-          $servivesambadc      = 'sernet-samba-ad'
-          $servivesmb          = 'sernet-samba-smbd'
-          $servivewinbind      = 'sernet-samba-winbindd'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/default/sernet-samba'
-          $sambaoptstmpl       = "${module_name}/sernet-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'python-yaml'
+          $packagesambadc         = 'sernet-samba-ad'
+          $packagesambaclassic    = 'sernet-samba'
+          $packagesambaclient     = 'sernet-samba-client'
+          $packagesambawinbind    = 'sernet-samba-winbind'
+          $packagesambansswinbind = 'sernet-samba-libs'
+          $servivesambadc         = 'sernet-samba-ad'
+          $servivesmb             = 'sernet-samba-smbd'
+          $servivewinbind         = 'sernet-samba-winbindd'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/default/sernet-samba'
+          $sambaoptstmpl          = "${module_name}/sernet-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'python-yaml'
       }
       default: {
           fail('unsupported os')
@@ -47,43 +49,45 @@ class samba::params(
   }else{
     case $::osfamily {
       'redhat': {
-          $packagesambadc      = 'samba-dc'
-          $packagesambaclassic = 'samba'
-          $packagesambawinbind = 'samba-winbind'
-          $packagesambaclient  = 'samba-client'
+          $packagesambadc         = 'samba-dc'
+          $packagesambaclassic    = 'samba'
+          $packagesambawinbind    = 'samba-winbind'
+          $packagesambansswinbind = 'samba-winbind-clients'
+          $packagesambaclient     = 'samba-client'
           # for now, this is not supported by Debian
-          $servivesambadc      = undef
-          $servivesmb          = 'smb'
-          $servivewinbind      = 'winbind'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/sysconfig/samba'
-          $sambaoptstmpl       = "${module_name}/redhat-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'PyYAML'
+          $servivesambadc         = undef
+          $servivesmb             = 'smb'
+          $servivewinbind         = 'winbind'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/sysconfig/samba'
+          $sambaoptstmpl          = "${module_name}/redhat-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'PyYAML'
       }
       'Debian': {
-          $packagesambadc      = 'samba'
-          $packagesambaclassic = 'samba'
-          $packagesambawinbind = 'winbind'
-          $packagesambaclient  = 'smbclient'
-          $servivesambadc      = 'samba-ad-dc'
+          $packagesambadc         = 'samba'
+          $packagesambaclassic    = 'samba'
+          $packagesambawinbind    = 'winbind'
+          $packagesambansswinbind = 'libnss-winbind'
+          $packagesambaclient     = 'smbclient'
+          $servivesambadc         = 'samba-ad-dc'
           if $::operatingsystem == 'Ubuntu' {
-            $servivesmb          = 'smbd'
+            $servivesmb           = 'smbd'
           } elsif ($::operatingsystem == 'Debian') and ($::operatingsystemmajrelease >= '8') {
-            $servivesmb          = 'smbd'
+            $servivesmb           = 'smbd'
           } else {
-            $servivesmb          = 'samba'
+            $servivesmb           = 'samba'
           }
-          $servivewinbind      = 'winbind'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/default/samba4'
-          $sambaoptstmpl       = "${module_name}/debian-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'python-yaml'
+          $servivewinbind         = 'winbind'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/default/samba4'
+          $sambaoptstmpl          = "${module_name}/debian-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'python-yaml'
       }
       default: {
           fail('unsupported os')


### PR DESCRIPTION
Ensure libnss-winbind is installed (Debian/Ubuntu) or samba-winbind-clients (RedHat). The RedHat and Sernet packages for this need testing - I checked for the correct packages online.
Test on Ubuntu 16.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/31)
<!-- Reviewable:end -->
