### PR TITLE
Add initial support for configuring PAM for winbind authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ class { '::samba::classic':
   krbconf               => true,             # * Deploy krb5.conf file (default: true)
   nsswitch              => true,             # * Add winbind to nsswitch,
                                              # (default: true)
+  pam                   => false,            # * Add winbind to pam (default: false)
   join_domain           => true,             # * Flag to enable domain join (default: true)
   adminuser             => 'custadmin'       # * Domain Administrator login
                                              # (default: 'administrator')

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -123,6 +123,11 @@ class samba::classic(
     }
 
     if $nsswitch {
+      package{ 'SambaNssWinbind':
+        ensure => 'installed',
+        name   => $::samba::params::packagesambansswinbind
+      }
+
       augeas{'samba nsswitch group':
         context => "/files/${::samba::params::nsswitchconffile}/",
         changes => [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class samba::params(
           $packagesambaclient     = 'sernet-samba-client'
           $packagesambawinbind    = 'sernet-samba-winbind'
           $packagesambansswinbind = 'sernet-samba-libs'
+          $packagesambapamwinbind = 'sernet-samba-libs'
           $servivesambadc         = 'sernet-samba-ad'
           $servivesmb             = 'sernet-samba-smbd'
           $servivewinbind         = 'sernet-samba-winbindd'
@@ -31,6 +32,7 @@ class samba::params(
           $packagesambaclient     = 'sernet-samba-client'
           $packagesambawinbind    = 'sernet-samba-winbind'
           $packagesambansswinbind = 'sernet-samba-libs'
+          $packagesambapamwinbind = 'sernet-samba-libs'
           $servivesambadc         = 'sernet-samba-ad'
           $servivesmb             = 'sernet-samba-smbd'
           $servivewinbind         = 'sernet-samba-winbindd'
@@ -53,6 +55,7 @@ class samba::params(
           $packagesambaclassic    = 'samba'
           $packagesambawinbind    = 'samba-winbind'
           $packagesambansswinbind = 'samba-winbind-clients'
+          $packagesambapamwinbind = 'samba-winbind-clients'
           $packagesambaclient     = 'samba-client'
           # for now, this is not supported by Debian
           $servivesambadc         = undef
@@ -71,6 +74,7 @@ class samba::params(
           $packagesambaclassic    = 'samba'
           $packagesambawinbind    = 'winbind'
           $packagesambansswinbind = 'libnss-winbind'
+          $packagesambapamwinbind = 'libpam-winbind'
           $packagesambaclient     = 'smbclient'
           $servivesambadc         = 'samba-ad-dc'
           if $::operatingsystem == 'Ubuntu' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,36 +9,38 @@ class samba::params(
   if $sernetpkgs {
     case $::osfamily {
       'redhat': {
-          $packagesambadc      = 'sernet-samba-ad'
-          $packagesambaclassic = 'sernet-samba'
-          $packagesambaclient  = 'sernet-samba-client'
-          $packagesambawinbind = 'sernet-samba-winbind'
-          $servivesambadc      = 'sernet-samba-ad'
-          $servivesmb          = 'sernet-samba-smbd'
-          $servivewinbind      = 'sernet-samba-winbindd'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/default/sernet-samba'
-          $sambaoptstmpl       = "${module_name}/sernet-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'PyYAML'
+          $packagesambadc         = 'sernet-samba-ad'
+          $packagesambaclassic    = 'sernet-samba'
+          $packagesambaclient     = 'sernet-samba-client'
+          $packagesambawinbind    = 'sernet-samba-winbind'
+          $packagesambansswinbind = 'sernet-samba-libs'
+          $servivesambadc         = 'sernet-samba-ad'
+          $servivesmb             = 'sernet-samba-smbd'
+          $servivewinbind         = 'sernet-samba-winbindd'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/default/sernet-samba'
+          $sambaoptstmpl          = "${module_name}/sernet-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'PyYAML'
       }
       'Debian': {
-          $packagesambadc      = 'sernet-samba-ad'
-          $packagesambaclassic = 'sernet-samba'
-          $packagesambaclient  = 'sernet-samba-client'
-          $packagesambawinbind = 'sernet-samba-winbind'
-          $servivesambadc      = 'sernet-samba-ad'
-          $servivesmb          = 'sernet-samba-smbd'
-          $servivewinbind      = 'sernet-samba-winbindd'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/default/sernet-samba'
-          $sambaoptstmpl       = "${module_name}/sernet-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'python-yaml'
+          $packagesambadc         = 'sernet-samba-ad'
+          $packagesambaclassic    = 'sernet-samba'
+          $packagesambaclient     = 'sernet-samba-client'
+          $packagesambawinbind    = 'sernet-samba-winbind'
+          $packagesambansswinbind = 'sernet-samba-libs'
+          $servivesambadc         = 'sernet-samba-ad'
+          $servivesmb             = 'sernet-samba-smbd'
+          $servivewinbind         = 'sernet-samba-winbindd'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/default/sernet-samba'
+          $sambaoptstmpl          = "${module_name}/sernet-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'python-yaml'
       }
       default: {
           fail('unsupported os')
@@ -47,43 +49,45 @@ class samba::params(
   }else{
     case $::osfamily {
       'redhat': {
-          $packagesambadc      = 'samba-dc'
-          $packagesambaclassic = 'samba'
-          $packagesambawinbind = 'samba-winbind'
-          $packagesambaclient  = 'samba-client'
+          $packagesambadc         = 'samba-dc'
+          $packagesambaclassic    = 'samba'
+          $packagesambawinbind    = 'samba-winbind'
+          $packagesambansswinbind = 'samba-winbind-clients'
+          $packagesambaclient     = 'samba-client'
           # for now, this is not supported by Debian
-          $servivesambadc      = undef
-          $servivesmb          = 'smb'
-          $servivewinbind      = 'winbind'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/sysconfig/samba'
-          $sambaoptstmpl       = "${module_name}/redhat-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'PyYAML'
+          $servivesambadc         = undef
+          $servivesmb             = 'smb'
+          $servivewinbind         = 'winbind'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/sysconfig/samba'
+          $sambaoptstmpl          = "${module_name}/redhat-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'PyYAML'
       }
       'Debian': {
-          $packagesambadc      = 'samba'
-          $packagesambaclassic = 'samba'
-          $packagesambawinbind = 'winbind'
-          $packagesambaclient  = 'smbclient'
-          $servivesambadc      = 'samba-ad-dc'
+          $packagesambadc         = 'samba'
+          $packagesambaclassic    = 'samba'
+          $packagesambawinbind    = 'winbind'
+          $packagesambansswinbind = 'libnss-winbind'
+          $packagesambaclient     = 'smbclient'
+          $servivesambadc         = 'samba-ad-dc'
           if $::operatingsystem == 'Ubuntu' {
-            $servivesmb          = 'smbd'
+            $servivesmb           = 'smbd'
           } elsif ($::operatingsystem == 'Debian') and ($::operatingsystemmajrelease >= '8') {
-            $servivesmb          = 'smbd'
+            $servivesmb           = 'smbd'
           } else {
-            $servivesmb          = 'samba'
+            $servivesmb           = 'samba'
           }
-          $servivewinbind      = 'winbind'
-          $sambacmd            = '/usr/bin/samba-tool'
-          $sambaclientcmd      = '/usr/bin/smbclient'
-          $sambaoptsfile       = '/etc/default/samba4'
-          $sambaoptstmpl       = "${module_name}/debian-samba.erb"
-          $smbconffile         = '/etc/samba/smb.conf'
-          $krbconffile         = '/etc/krb5.conf'
-          $packagepyyaml       = 'python-yaml'
+          $servivewinbind         = 'winbind'
+          $sambacmd               = '/usr/bin/samba-tool'
+          $sambaclientcmd         = '/usr/bin/smbclient'
+          $sambaoptsfile          = '/etc/default/samba4'
+          $sambaoptstmpl          = "${module_name}/debian-samba.erb"
+          $smbconffile            = '/etc/samba/smb.conf'
+          $krbconffile            = '/etc/krb5.conf'
+          $packagepyyaml          = 'python-yaml'
       }
       default: {
           fail('unsupported os')

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
   "issues_url": "https://github.com/kakwa/puppet-samba/issues",
   "tags": ["samba", "fileserver", "cifs", "smb", "Domain", "Controller", "DC", "AD", "Active", "Directory"],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 3.0.0"}
+    {"name":"puppetlabs-stdlib","version_requirement":">= 3.0.0"},
+    {"name":"augeasproviders_pam","version_requirement":">= 2.1.0"}
   ],
   "operatingsystem_support": [
     {
@@ -36,7 +37,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04"
+        "14.04",
+        "16.04",
       ]
     }
   ]


### PR DESCRIPTION
Open to feedback - I'm new to puppet so there may be better ways to do a lot of this stuff.
This adds a dependency on the module augeasproviders_pam.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/32)
<!-- Reviewable:end -->
