### PR TITLE
Skip package declaration when pam-winbind and nss-winbind packages are the same

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -152,7 +152,10 @@ class samba::classic(
     }
 
     if $pam {
-      if ($::samba::params::packagesambapamwinbind != $::samba::params::packagesambansswinbind) and !$nsswitch {
+      # Only add package here if different to the nss-winbind package,
+      # or nss and pam aren't both enabled, to avoid duplicate definition.
+      if ($::samba::params::packagesambapamwinbind != $::samba::params::packagesambansswinbind)
+      or !$nsswitch {
         package{ 'SambaPamWinbind':
           ensure => 'installed',
           name   => $::samba::params::packagesambapamwinbind

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -152,9 +152,11 @@ class samba::classic(
     }
 
     if $pam {
-      package{ 'SambaPamWinbind':
-        ensure => 'installed',
-        name   => $::samba::params::packagesambapamwinbind
+      if ($::samba::params::packagesambapamwinbind != $::samba::params::packagesambansswinbind) and !$nsswitch {
+        package{ 'SambaPamWinbind':
+          ensure => 'installed',
+          name   => $::samba::params::packagesambapamwinbind
+        }
       }
 
       if $krbconf {


### PR DESCRIPTION
Enabling pam and nss options to the module on RHEL family distros tries to include the same package resource twice, so we need to skip one if this is the case.

(Could use virtual resources or a separate class, but this seemed the simplest fix for this one off case :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/36)
<!-- Reviewable:end -->
