### PR TITLE
Add the ability to create DNS zones and entries via puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,31 @@ If you want to create subdirectory in a share with specific permissions/acls:
 }
 ```
 
+#### DNS Zones 
+
+If you want to create a DNS zone (most useful for creating the reverse zone after DC creation):
+
+```puppet
+::samba::dc::dnszone { 'Reverse Zone':
+  # Mandatory parameters
+  zone              => '0.168.192.in-addr.arpa'
+}
+```
+
+#### DNS Entries
+
+If you want to create a DNS entry (most useful for creating the reverse DNS entries):
+
+```puppet
+::samba::dc::dnszone { 'Reverse Entry':
+  # Mandatory parameters
+  zone              => '0.168.192.in-addr.arpa'
+  host              => '1'
+  type              => 'PTR'
+  record            => 'dc.samdom.example.com.'
+}
+```
+
 ## Limitations
 
 class **samba::dc** (deploy Samba as a Domain Controller) needs Samba in version 4.0.0 or above.

--- a/manifests/dc/dnsentry.pp
+++ b/manifests/dc/dnsentry.pp
@@ -1,0 +1,71 @@
+# == Class: samba
+#
+# Full description of class samba here.
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*sample_parameter*]
+#   Explanation of what this parameter affects and what it defaults to.
+#   e.g. "Specify one or more upstream ntp servers as an array."
+#
+# === Variables
+#
+# Here you should define a list of variables that this module would require.
+#
+# [*sample_variable*]
+#   Explanation of how this variable affects the funtion of this class and if
+#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
+#   External Node Classifier as a comma separated list of hostnames." (Note,
+#   global variables should be avoided in favor of class parameters as
+#   of Puppet 2.6.)
+#
+# === Examples
+#
+#  class { 'samba':
+#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
+#  }
+#
+# === Authors
+#
+# Pierre-Francois Carpentier <carpentier.pf@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2015 Pierre-Francois Carpentier, unless otherwise noted.
+#
+
+define samba::dc::dnsentry(
+    $zone                 = undef,
+    $host                 = undef,
+    $type                 = undef,
+    $record               = undef,
+    ) {
+
+  unless $zone{
+    fail('zone must be a valid domain')
+  }
+
+  unless $host{
+    fail('host must be a valid hostname')
+  }
+
+  unless $type{
+    fail('type must be a valid dns record type')
+  }
+
+  unless $record{
+    fail('record must be a valid dns record')
+  }
+
+  exec { "dnsentry ${title}":
+    path    => '/bin:/usr/sbin:/usr/bin',
+    unless  => "samba-tool dns query -P localhost ${zone} ${host} ${type}",
+    command => "samba-tool dns add -P localhost ${zone} ${host} ${type} ${record}",
+  }
+
+  Samba::Dc::Dnszone<| |> -> Samba::Dc::Dnsentry<| |>
+}
+
+# vim: tabstop=8 expandtab shiftwidth=2 softtabstop=2

--- a/manifests/dc/dnszone.pp
+++ b/manifests/dc/dnszone.pp
@@ -1,0 +1,56 @@
+# == Class: samba
+#
+# Full description of class samba here.
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*sample_parameter*]
+#   Explanation of what this parameter affects and what it defaults to.
+#   e.g. "Specify one or more upstream ntp servers as an array."
+#
+# === Variables
+#
+# Here you should define a list of variables that this module would require.
+#
+# [*sample_variable*]
+#   Explanation of how this variable affects the funtion of this class and if
+#   it has a default. e.g. "The parameter enc_ntp_servers must be set by the
+#   External Node Classifier as a comma separated list of hostnames." (Note,
+#   global variables should be avoided in favor of class parameters as
+#   of Puppet 2.6.)
+#
+# === Examples
+#
+#  class { 'samba':
+#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ],
+#  }
+#
+# === Authors
+#
+# Pierre-Francois Carpentier <carpentier.pf@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2015 Pierre-Francois Carpentier, unless otherwise noted.
+#
+
+define samba::dc::dnszone(
+    $zone                 = undef,
+    ) {
+
+  unless $zone{
+    fail('zone must be a valid domain')
+  }
+
+  exec { "dnszone ${title}":
+    path    => '/bin:/usr/sbin:/usr/bin',
+    unless  => "samba-tool dns zonelist -P localhost | egrep \"pszZoneName(\s)+:(\s+)${zone}\"",
+    command => "samba-tool dns zonecreate -P localhost ${zone}",
+  }
+
+  Service['SambaDC'] -> Samba::Dc::Dnszone<| |>
+}
+
+# vim: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
This is most useful for creating the reverse zones required automatically after your DC build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/38)
<!-- Reviewable:end -->
