### PR TITLE
enabling more variable overwriting

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -37,26 +37,36 @@
 #
 
 class samba::classic(
-  $smbname              = undef,
-  $domain               = undef,
-  $realm                = undef,
-  $strictrealm          = true,
-  $adminuser            = 'administrator',
-  $adminpassword        = undef,
-  $security             = 'ads',
-  $sambaloglevel        = 1,
-  $join_domain          = true,
-  $manage_winbind       = true,
-  $krbconf              = true,
-  $nsswitch             = true,
-  $pam                  = false,
-  $sambaclassloglevel   = undef,
-  $logtosyslog          = false,
-  $globaloptions        = {},
-  $globalabsentoptions  = [],
-  $joinou               = undef,
-  $default_realm        = undef,
-  $additional_realms    = [],
+  $smbname                = undef,
+  $domain                 = undef,
+  $realm                  = undef,
+  $strictrealm            = true,
+  $adminuser              = 'administrator',
+  $adminpassword          = undef,
+  $security               = 'ads',
+  $sambaloglevel          = 1,
+  $join_domain            = true,
+  $manage_winbind         = true,
+  $krbconf                = true,
+  $nsswitch               = true,
+  $pam                    = false,
+  $sambaclassloglevel     = undef,
+  $logtosyslog            = false,
+  $globaloptions          = {},
+  $globalabsentoptions    = [],
+  $joinou                 = undef,
+  $default_realm          = undef,
+  $additional_realms      = [],
+  $packagesambaclassic    = $::samba::params::packagesambaclassic,
+  $packagesambawinbind    = $::samba::params::packagesambawinbind,
+  $packagesambansswinbind = $::samba::params::packagesambansswinbind
+  $packagesambapamwinbind = $::samba::params::packagesambapamwinbind
+  $servivesmb             = $::samba::params::servivesmb,
+  $servivewinbind         = $::samba::params::servivewinbind,
+  $sambaoptsfile          = $::samba::params::sambaoptsfile,
+  $sambaoptstmpl          = $::samba::params::sambaoptstmpl,
+  $smbconffile            = $::samba::params::smbconffile,
+  $krbconffile            = $::samba::params::krbconffile,
 ) inherits ::samba::params{
 
 
@@ -109,13 +119,13 @@ class samba::classic(
 
   file { '/etc/samba/smb_path':
     ensure  => 'present',
-    content => $::samba::params::smbconffile,
+    content => $smbconffile,
     require => File['/etc/samba/'],
   }
 
   if $join_domain {
     if $krbconf {
-      file {$::samba::params::krbconffile:
+      file {$krbconffile:
         ensure  => present,
         mode    => '0644',
         content => template("${module_name}/krb5.conf.erb"),
@@ -126,7 +136,7 @@ class samba::classic(
     if $nsswitch {
       package{ 'SambaNssWinbind':
         ensure => 'installed',
-        name   => $::samba::params::packagesambansswinbind
+        name   => $packagesambansswinbind
       }
 
       augeas{'samba nsswitch group':
@@ -154,11 +164,11 @@ class samba::classic(
     if $pam {
       # Only add package here if different to the nss-winbind package,
       # or nss and pam aren't both enabled, to avoid duplicate definition.
-      if ($::samba::params::packagesambapamwinbind != $::samba::params::packagesambansswinbind)
+      if ($packagesambapamwinbind != $packagesambansswinbind)
       or !$nsswitch {
         package{ 'SambaPamWinbind':
           ensure => 'installed',
-          name   => $::samba::params::packagesambapamwinbind
+          name   => $packagesambapamwinbind
         }
       }
 
@@ -211,13 +221,13 @@ class samba::classic(
 
   package{ 'SambaClassic':
     ensure => 'installed',
-    name   => $::samba::params::packagesambaclassic,
+    name   => $packagesambaclassic,
   }
 
   if $manage_winbind {
     package{ 'SambaClassicWinBind':
       ensure  => 'installed',
-      name    => $::samba::params::packagesambawinbind,
+      name    => $packagesambawinbind,
       require => File['/etc/samba/smb_path'],
     }
     Package['SambaClassicWinBind'] -> Package['SambaClassic']
@@ -225,7 +235,7 @@ class samba::classic(
 
   service{ 'SambaSmb':
     ensure  => 'running',
-    name    => $::samba::params::servivesmb,
+    name    => $servivesmb,
     require => [ Package['SambaClassic'], File['SambaOptsFile'] ],
     enable  => true,
   }
@@ -233,7 +243,7 @@ class samba::classic(
   if $manage_winbind {
     service{ 'SambaWinBind':
       ensure  => 'running',
-      name    => $::samba::params::servivewinbind,
+      name    => $servivewinbind,
       require => [ Package['SambaClassic'], File['SambaOptsFile'] ],
       enable  => true,
     }
@@ -241,8 +251,8 @@ class samba::classic(
   $sambamode = 'classic'
   # Deploy /etc/sysconfig/|/etc/defaut/ file (startup options)
   file{ 'SambaOptsFile':
-    path    => $::samba::params::sambaoptsfile,
-    content => template($::samba::params::sambaoptstmpl),
+    path    => $sambaoptsfile,
+    content => template($sambaoptstmpl),
     require => Package['SambaClassic'],
   }
 

--- a/manifests/dc/ppolicy_param.pp
+++ b/manifests/dc/ppolicy_param.pp
@@ -4,6 +4,7 @@ define samba::dc::ppolicy_param(
   $option,
   $show_string,
   $value,
+  $sambacmd = $::samba::params::sambacmd,
 ){
 
   validate_re(
@@ -29,10 +30,10 @@ corresponding to option",
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',
     require => Service['SambaDC'],
     unless  => "[ \
-\"\$( ${::samba::params::sambacmd} domain passwordsettings show -d 1 | \
+\"\$( ${sambacmd} domain passwordsettings show -d 1 | \
 sed 's/${show_string} *//p;d' )\" = \
 '${value}' ]",
-    command => "${::samba::params::sambacmd} domain passwordsettings set -d 1 \
+    command => "${sambacmd} domain passwordsettings set -d 1 \
 ${option}='${value}'",
   }
 }

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -5,6 +5,7 @@ define samba::log(
   $logtosyslog,
   $settingsignored,
   $sambaclassloglevel = undef,
+  $smbconffile = $::samba:params::smbconffile,
 ) {
 
   unless is_integer($sambaloglevel)
@@ -40,7 +41,7 @@ define samba::log(
   unless member($settingsignored, 'log level'){
     smb_setting { 'global/log level':
       ensure  => present,
-      path    => $::samba::params::smbconffile,
+      path    => $smbconffile,
       section => 'global',
       setting => 'log level',
       value   => "${sambaloglevel}${logadditional}",
@@ -53,7 +54,7 @@ define samba::log(
       unless member($settingsignored, 'syslog'){
         smb_setting { 'global/syslog':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $smbconffile,
           section => 'global',
           setting => 'syslog',
           value   => "${sambaloglevel}${logadditional}",
@@ -63,7 +64,7 @@ define samba::log(
       unless member($settingsignored, 'syslog only'){
         smb_setting { 'global/syslog only':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $smbconffile,
           section => 'global',
           setting => 'syslog only',
           value   => 'yes',
@@ -73,7 +74,7 @@ define samba::log(
       unless member($settingsignored, 'logging'){
         smb_setting { 'global/logging':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $smbconffile,
           section => 'global',
           setting => 'logging',
           value   => $syslog_loglevel,
@@ -87,7 +88,7 @@ define samba::log(
       unless member($settingsignored, 'syslog only'){
         smb_setting { 'global/syslog only':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $smbconffile,
           section => 'global',
           setting => 'syslog only',
           value   => 'no',
@@ -97,7 +98,7 @@ define samba::log(
       unless member($settingsignored, 'syslog'){
         smb_setting { 'global/syslog':
           ensure  => absent,
-          path    => $::samba::params::smbconffile,
+          path    => $smbconffile,
           section => 'global',
           setting => 'syslog',
         }
@@ -106,7 +107,7 @@ define samba::log(
       unless member($settingsignored, 'logging'){
         smb_setting { 'global/logging':
           ensure  => absent,
-          path    => $::samba::params::smbconffile,
+          path    => $smbconffile,
           section => 'global',
           setting => 'logging',
         }

--- a/manifests/option.pp
+++ b/manifests/option.pp
@@ -4,6 +4,7 @@ define samba::option(
       $options,
       $section,
       $settingsignored = [],
+      $smbconffile = $::samba::params::smbconffile,
 ){
   $optionssetting = regsubst($title, '^\[.*\](.*)$', '\1')
   $optionsvalue   = $options[$optionssetting]
@@ -11,7 +12,7 @@ define samba::option(
   unless member($settingsignored, $optionssetting){
     smb_setting { "${section}/${optionssetting}":
       ensure            => present,
-      path              => $::samba::params::smbconffile,
+      path              => $smbconffile,
       section           => $section,
       setting           => $optionssetting,
       value             => $optionsvalue,

--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -45,6 +45,7 @@ define samba::share(
   $mode  = '0777',
   $acl   = undef,
   $manage_directory = true,
+  $smbconffile = $::samba::params::smbconffile,
 ) {
 
   if defined(Package['SambaClassic']){
@@ -77,7 +78,7 @@ define samba::share(
     }
 
     smb_setting { "${name}/path":
-      path    => $::samba::params::smbconffile,
+      path    => $smbconffile,
       section => $name,
       setting => 'path',
       value   => $path,


### PR DESCRIPTION
 * overwrite path to binarys when using the module in another class
 * overwrite package names (useful to use modules with private
   sernet packages)

In detail we use the private sernet packages and the support for it was dropped in the last version. With these changes we can use the module and overwrite package names and still can use the packages from sernet and the upstream puppet-samba code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/42)
<!-- Reviewable:end -->
