### PR TITLE
fixed overwriting of generic variables

### DIFF
--- a/manifests/dir.pp
+++ b/manifests/dir.pp
@@ -53,8 +53,8 @@ define samba::dir(
 
   exec {"Create path ${rootpath}":
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',
-    unless  => "test -e '${rootpath}'",
     command => "mkdir -p '${rootpath}'",
+    creates => '${rootpath}',
   }
 
   file {$rootpath:

--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -48,16 +48,16 @@ define samba::share(
 ) {
 
   if defined(Package['SambaClassic']){
-    $require = Package['SambaClassic']
+    $smb_require = Package['SambaClassic']
     if defined(Service['SambaWinbind']) {
-      $notify  = Service['SambaSmb', 'SambaWinBind']
+      $smb_notify  = Service['SambaSmb', 'SambaWinBind']
     }
     else {
-      $notify  = Service['SambaSmb']
+      $smb_notify  = Service['SambaSmb']
     }
   }elsif defined(Package['SambaDC']){
-    $require = Exec['provisionAD']
-    $notify  = Service['SambaDC']
+    $smb_require = Exec['provisionAD']
+    $smb_notify  = Service['SambaDC']
   }else{
     fail('No mode matched, Missing class samba::classic or samba::dc?')
   }
@@ -81,8 +81,8 @@ define samba::share(
       section => $name,
       setting => 'path',
       value   => $path,
-      require => $require,
-      notify  => $notify,
+      require => $smb_require,
+      notify  => $smb_notify,
     }
   }
 
@@ -90,8 +90,8 @@ define samba::share(
   ::samba::option{ $optionsindex:
     options => $options,
     section => $name,
-    require => $require,
-    notify  => $notify,
+    require => $smb_require,
+    notify  => $smb_notify,
   }
 
   $absoptlist = prefix($absentoptions, $name)


### PR DESCRIPTION
there are declared variables (require and notify) which causes puppet to fail if setting require and notify to ::samba::share class
Also a small fix in the exec resource (using creates instead of bash command unless)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/44)
<!-- Reviewable:end -->
