### PR TITLE
switch from topscope to relative scope

### DIFF
--- a/manifests/dc/ppolicy.pp
+++ b/manifests/dc/ppolicy.pp
@@ -7,7 +7,7 @@ class samba::dc::ppolicy (
   $ppolicyminpwdlength   = 7,
   $ppolicyminpwdage      = 1,
   $ppolicymaxpwdage      = 42,
-) inherits ::samba::params{
+) inherits samba::params{
   $checkpp = ['on', 'off', 'default']
   $checkppstr = join($checkpp, ', ')
 

--- a/manifests/dc/ppolicy_param.pp
+++ b/manifests/dc/ppolicy_param.pp
@@ -29,10 +29,10 @@ corresponding to option",
     path    => '/bin:/sbin:/usr/bin:/usr/sbin',
     require => Service['SambaDC'],
     unless  => "[ \
-\"\$( ${::samba::params::sambacmd} domain passwordsettings show -d 1 | \
+\"\$( ${samba::params::sambacmd} domain passwordsettings show -d 1 | \
 sed 's/${show_string} *//p;d' )\" = \
 '${value}' ]",
-    command => "${::samba::params::sambacmd} domain passwordsettings set -d 1 \
+    command => "${samba::params::sambacmd} domain passwordsettings set -d 1 \
 ${option}='${value}'",
   }
 }

--- a/manifests/dc/script.pp
+++ b/manifests/dc/script.pp
@@ -6,7 +6,7 @@ define samba::dc::script(
   $scriptname       = $name
   $scriptcontent    = $content
 
-  $scriptpath = "${::samba::dc::scriptdir}/${scriptname}"
+  $scriptpath = "${samba::dc::scriptdir}/${scriptname}"
   validate_absolute_path($scriptpath)
 
   file { $scriptpath:

--- a/manifests/idmap.pp
+++ b/manifests/idmap.pp
@@ -176,7 +176,7 @@ echo '${ldap_passwd}' | sha1sum >${hash_ldap}",
 
   $idmapoptionsindex = prefix(keys($idmapoptions),
       '[global]')
-  ::samba::option{ $idmapoptionsindex:
+  samba::option{ $idmapoptionsindex:
     options => $idmapoptions,
     section => 'global',
     require => $package,

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -1,4 +1,4 @@
-# log resource 
+# log resource
 
 define samba::log(
   $sambaloglevel,
@@ -13,7 +13,7 @@ define samba::log(
     fail('loglevel must be an integer between 0 and 10')
   }
 
-  $classlist = $::samba::params::logclasslist
+  $classlist = $samba::params::logclasslist
   $classliststr = join($classlist, ', ')
 
   if $sambaclassloglevel != undef {
@@ -40,7 +40,7 @@ define samba::log(
   unless member($settingsignored, 'log level'){
     smb_setting { 'global/log level':
       ensure  => present,
-      path    => $::samba::params::smbconffile,
+      path    => $samba::params::smbconffile,
       section => 'global',
       setting => 'log level',
       value   => "${sambaloglevel}${logadditional}",
@@ -49,11 +49,11 @@ define samba::log(
 
   # If specify, configure syslog
   if $logtosyslog {
-    if versioncmp($::samba_version, '4.3.0') <= 0 {
+    if versioncmp($facts['samba_version'], '4.3.0') <= 0 {
       unless member($settingsignored, 'syslog'){
         smb_setting { 'global/syslog':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $samba::params::smbconffile,
           section => 'global',
           setting => 'syslog',
           value   => "${sambaloglevel}${logadditional}",
@@ -63,7 +63,7 @@ define samba::log(
       unless member($settingsignored, 'syslog only'){
         smb_setting { 'global/syslog only':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $samba::params::smbconffile,
           section => 'global',
           setting => 'syslog only',
           value   => 'yes',
@@ -73,7 +73,7 @@ define samba::log(
       unless member($settingsignored, 'logging'){
         smb_setting { 'global/logging':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $samba::params::smbconffile,
           section => 'global',
           setting => 'logging',
           value   => $syslog_loglevel,
@@ -83,11 +83,11 @@ define samba::log(
   }
   # If not, keep login ing file, and disable syslog
   else {
-    if versioncmp($::samba_version, '4.3.0') <= 0 {
+    if versioncmp($facts['samba_version'], '4.3.0') <= 0 {
       unless member($settingsignored, 'syslog only'){
         smb_setting { 'global/syslog only':
           ensure  => present,
-          path    => $::samba::params::smbconffile,
+          path    => $samba::params::smbconffile,
           section => 'global',
           setting => 'syslog only',
           value   => 'no',
@@ -97,7 +97,7 @@ define samba::log(
       unless member($settingsignored, 'syslog'){
         smb_setting { 'global/syslog':
           ensure  => absent,
-          path    => $::samba::params::smbconffile,
+          path    => $samba::params::smbconffile,
           section => 'global',
           setting => 'syslog',
         }
@@ -106,7 +106,7 @@ define samba::log(
       unless member($settingsignored, 'logging'){
         smb_setting { 'global/logging':
           ensure  => absent,
-          path    => $::samba::params::smbconffile,
+          path    => $samba::params::smbconffile,
           section => 'global',
           setting => 'logging',
         }

--- a/manifests/option.pp
+++ b/manifests/option.pp
@@ -11,7 +11,7 @@ define samba::option(
   unless member($settingsignored, $optionssetting){
     smb_setting { "${section}/${optionssetting}":
       ensure            => present,
-      path              => $::samba::params::smbconffile,
+      path              => $samba::params::smbconffile,
       section           => $section,
       setting           => $optionssetting,
       value             => $optionsvalue,

--- a/manifests/share.pp
+++ b/manifests/share.pp
@@ -67,7 +67,7 @@ define samba::share(
     validate_absolute_path($rootpath)
 
     if $manage_directory {
-      ::samba::dir {$rootpath:
+      samba::dir {$rootpath:
         path  => $rootpath,
         owner => $owner,
         group => $group,
@@ -87,7 +87,7 @@ define samba::share(
   }
 
   $optionsindex = prefix(keys($options), "[${name}]")
-  ::samba::option{ $optionsindex:
+  samba::option{ $optionsindex:
     options => $options,
     section => $name,
     require => $require,


### PR DESCRIPTION
topscope access to variables and classes isn't needed in modern puppet
versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/45)
<!-- Reviewable:end -->
