### PR TITLE
Permit override of package names

### DIFF
--- a/lib/facter/samba_version.rb
+++ b/lib/facter/samba_version.rb
@@ -8,11 +8,11 @@ distid = Facter.value(:operatingsystem)
 
 case distid
     when /RedHatEnterprise|CentOS|Fedora|RHEL/
-        if  FileTest.exists?("/usr/bin/yum")
+        if  FileTest.exist?("/usr/bin/yum")
             version = Facter::Util::Resolution.exec('/usr/bin/yum info samba | sed \'s/Version *: \([0-9\.]\+\)/\1/gp;d\' | head -n 1')
         end
     when /Ubuntu|Debian/
-        if  FileTest.exists?("/usr/bin/apt-cache")
+        if  FileTest.exist?("/usr/bin/apt-cache")
             version = Facter::Util::Resolution.exec('apt-cache show samba | sed \'s/Version:.*:\([0-9\.]\+\).*/\1/gp;d\' | head -n 1')
         end
     when 'Archlinux'

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -69,16 +69,12 @@ class samba::classic(
 ) inherits samba::params{
 
 
-  unless is_domain_name($realm){
+  unless $realm =~ Stdlib::Host {
     fail('realm must be a valid domain')
   }
 
-  unless is_domain_name($realm){
-    fail('realm must be a valid domain')
-  }
-
-  validate_slength($smbname, 15)
-  unless is_domain_name("${smbname}.${realm}"){
+  assert_type(String[1, 15], $smbname)
+  unless "${smbname}.${realm}" =~ Stdlib::Host {
     fail('smbname must be a valid domain')
   }
 

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -342,7 +342,7 @@ class samba::classic(
         unless  => 'net ads testjoin',
         command => "echo '${adminpassword}'| net ads join -U '${adminuser}' ${ou}",
         notify  => Service['SambaWinBind'],
-        #require => [ Package['SambaClassic'], Service['SambaSmb'] ],
+        require => Package['SambaClassic'],
       }
     }
   }

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -349,10 +349,10 @@ class samba::classic(
         #$machinepass_env = [ "MACHINE_PASSWORD=${machinepass}", ]
         notify { "samba domain join being attempted with machinepass=${machinepass}": }
         $pass = "machinepass=${machinepass}"
-        $machinepass_env = undef
+        $machinepass_env = [ ]
       } else {
         $pass = ''
-        $machinepass_env = undef
+        $machinepass_env = [ ]
       }
       exec{ 'Join Domain':
         path        => '/bin:/sbin:/usr/sbin:/usr/bin/',

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -344,6 +344,9 @@ class samba::classic(
         notify  => Service['SambaWinBind'],
         require => Package['SambaClassic'],
       }
+
+      # Add dependency for domain join to require all config options applied
+      Samba::Option <| |> -> Exec['Join Domain']
     }
   }
 }

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -342,7 +342,7 @@ class samba::classic(
         unless  => 'net ads testjoin',
         command => "echo '${adminpassword}'| net ads join -U '${adminuser}' ${ou}",
         notify  => Service['SambaWinBind'],
-        require => [ Package['SambaClassic'], Service['SambaSmb'] ],
+        #require => [ Package['SambaClassic'], Service['SambaSmb'] ],
       }
     }
   }

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -57,12 +57,12 @@ class samba::classic(
   $joinou                         = undef,
   Optional[String] $default_realm = undef,
   Array $additional_realms        = [],
-  $packagesambadc                 = $samba::params::packagesambadc,
-  $packagesambaclassic            = $samba::params::packagesambaclassic,
-  $packagesambawinbind            = $samba::params::packagesambawinbind,
-  $packagesambansswinbind         = $samba::params::packagesambansswinbind,
-  $packagesambapamwinbind         = $samba::params::packagesambapamwinbind,
-  $packagesambaclient             = $samba::params::packagesambaclient,
+  $packagesambadc                 = $::samba::params::packagesambadc,
+  $packagesambaclassic            = $::samba::params::packagesambaclassic,
+  $packagesambawinbind            = $::samba::params::packagesambawinbind,
+  $packagesambansswinbind         = $::samba::params::packagesambansswinbind,
+  $packagesambapamwinbind         = $::samba::params::packagesambapamwinbind,
+  $packagesambaclient             = $::samba::params::packagesambaclient,
 ) inherits samba::params{
 
 

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -57,6 +57,12 @@ class samba::classic(
   $joinou                         = undef,
   Optional[String] $default_realm = undef,
   Array $additional_realms        = [],
+  $packagesambadc                 = $samba::params::packagesambadc,
+  $packagesambaclassic            = $samba::params::packagesambaclassic,
+  $packagesambawinbind            = $samba::params::packagesambawinbind,
+  $packagesambansswinbind         = $samba::params::packagesambansswinbind,
+  $packagesambapamwinbind         = $samba::params::packagesambapamwinbind,
+  $packagesambaclient             = $samba::params::packagesambaclient,
 ) inherits samba::params{
 
 
@@ -118,7 +124,7 @@ class samba::classic(
     if $nsswitch {
       package{ 'SambaNssWinbind':
         ensure => 'installed',
-        name   => $samba::params::packagesambansswinbind
+        name   => $packagesambansswinbind
       }
 
       augeas{'samba nsswitch group':
@@ -146,11 +152,11 @@ class samba::classic(
     if $pam {
       # Only add package here if different to the nss-winbind package,
       # or nss and pam aren't both enabled, to avoid duplicate definition.
-      if ($samba::params::packagesambapamwinbind != $samba::params::packagesambansswinbind)
+      if ($packagesambapamwinbind != $packagesambansswinbind)
       or !$nsswitch {
         package{ 'SambaPamWinbind':
           ensure => 'installed',
-          name   => $::samba::params::packagesambapamwinbind
+          name   => $packagesambapamwinbind
         }
       }
 
@@ -203,13 +209,13 @@ class samba::classic(
 
   package{ 'SambaClassic':
     ensure => 'installed',
-    name   => $samba::params::packagesambaclassic,
+    name   => $packagesambaclassic,
   }
 
   if $manage_winbind {
     package{ 'SambaClassicWinBind':
       ensure  => 'installed',
-      name    => $samba::params::packagesambawinbind,
+      name    => $packagesambawinbind,
       require => File['/etc/samba/smb_path'],
     }
     Package['SambaClassicWinBind'] -> Package['SambaClassic']

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -344,8 +344,12 @@ class samba::classic(
         default => '',
       }
       if $machinepass {
-        $pass = "machinepass=\"\${MACHINE_PASSWORD}\""
-        $machinepass_env = [ "MACHINE_PASSWORD=${machinepass}", ]
+        # Debug output -- put pass on command-line  :)
+        #$pass = "machinepass=\"\${MACHINE_PASSWORD}\""
+        #$machinepass_env = [ "MACHINE_PASSWORD=${machinepass}", ]
+        notify { "samba domain join being attempted with machinepass=${machinepass}": }
+        $pass = "machinepass=${machinepass}"
+        $machinepass_env = undef
       } else {
         $pass = ''
         $machinepass_env = undef

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -236,6 +236,7 @@ class samba::classic(
       ensure  => 'running',
       name    => $samba::params::servivewinbind,
       require => [ Package['SambaClassic'], File['SambaOptsFile'] ],
+      before  => [ Service['SambaSmb'] ], # required for smbd to run now
       enable  => true,
     }
   }

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -343,17 +343,17 @@ class samba::classic(
         false   => '--no-dns-updates',
         default => '',
       }
-      $pass = $machinepass ? {
-        default => "machinepass=\"\$MACHINE_PASSWORD\"",
-        undef   => '',
+      if $machinepass {
+        $pass = "machinepass=\"\${MACHINE_PASSWORD}\""
+        $machinepass_env = [ "MACHINE_PASSWORD=${machinepass}", ]
+      } else {
+        $pass = ''
+        $machinepass_env = undef
       }
       exec{ 'Join Domain':
         path        => '/bin:/sbin:/usr/sbin:/usr/bin/',
         unless      => 'net ads testjoin',
-        environment => [
-          "NET_PASSWORD=${adminpassword}",
-          "MACHINE_PASSWORD=${machinepass}",
-        ],
+        environment => [ "NET_PASSWORD=${adminpassword}", ] + $machinepass_env,
         command     => "echo \$NET_PASSWORD | net ads join -U '${adminuser}' ${no_dns_updates} ${ou} ${pass}",
         notify      => Service['SambaWinBind'],
         require     => Package['SambaClassic'],

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -46,7 +46,7 @@ class samba::classic(
   $security                       = 'ads',
   $sambaloglevel                  = 1,
   $join_domain                    = true,
-  Boolean $force_join             = false,
+  #Boolean $force_join             = false,
   $join_dns_update                = true,
   $manage_winbind                 = true,
   $krbconf                        = true,
@@ -345,26 +345,27 @@ class samba::classic(
         default => '',
       }
       if $machinepass {
-        # Debug output -- put pass on command-line  :<
-        $pass = "machinepass=\"\${MACHINE_PASSWORD}\""
-        $machinepass_env = [ "MACHINE_PASSWORD=${machinepass}", ]
+        # Debug output -- put pass on command-line  :)
+        #$pass = "machinepass=\"\${MACHINE_PASSWORD}\""
+        #$machinepass_env = [ "MACHINE_PASSWORD=${machinepass}", ]
         #notify { "samba domain join being attempted with machinepass=${machinepass}": }
-        #$pass = "machinepass=${machinepass}"
-        #$machinepass_env = [ ]
+        $pass = "machinepass=${machinepass}"
+        $machinepass_env = [ ]
       } else {
         $pass = ''
         $machinepass_env = [ ]
       }
 
-      if $force_join {
-        $unlesstest = 'false'
-      } else {
-        $unlesstest = 'net ads testjoin'
-      }
+      #if $force_join {
+      #  $unlesstest = 'false'
+      #} else {
+      #  $unlesstest = 'net ads testjoin'
+      #}
 
       exec{ 'Join Domain':
         path        => '/bin:/sbin:/usr/sbin:/usr/bin/',
-        unless      => $unlesstest,
+        #unless      => $unlesstest,
+        unless      => 'net ads testjoin',
         environment => [ "NET_PASSWORD=${adminpassword}", ] + $machinepass_env,
         command     => "echo \$NET_PASSWORD | net ads join -U '${adminuser}' ${no_dns_updates} ${ou} ${pass}",
         notify      => Service['SambaWinBind'],

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -46,7 +46,7 @@ class samba::classic(
   $security                       = 'ads',
   $sambaloglevel                  = 1,
   $join_domain                    = true,
-  #Boolean $force_join             = false,
+  Boolean $force_join             = false,
   $join_dns_update                = true,
   $manage_winbind                 = true,
   $krbconf                        = true,
@@ -356,16 +356,16 @@ class samba::classic(
         $machinepass_env = [ ]
       }
 
-      #if $force_join {
-      #  $unlesstest = 'false'
-      #} else {
-      #  $unlesstest = 'net ads testjoin'
-      #}
+      if $force_join {
+        $unlesstest = 'false'
+      } else {
+        $unlesstest = 'net ads testjoin'
+      }
 
       exec{ 'Join Domain':
         path        => '/bin:/sbin:/usr/sbin:/usr/bin/',
-        #unless      => $unlesstest,
-        unless      => 'net ads testjoin',
+        unless      => $unlesstest,
+        #unless      => 'net ads testjoin',
         environment => [ "NET_PASSWORD=${adminpassword}", ] + $machinepass_env,
         command     => "echo \$NET_PASSWORD | net ads join -U '${adminuser}' ${no_dns_updates} ${ou} ${pass}",
         notify      => Service['SambaWinBind'],

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -346,7 +346,7 @@ class samba::classic(
         path        => '/bin:/sbin:/usr/sbin:/usr/bin/',
         unless      => 'net ads testjoin',
         environment => ["NET_PASSWORD=${adminpassword}"],
-        command     => "echo \$NET_PASSWORD | net ads join -U '${adminuser}' ${no_dns_updates} ${ou}"
+        command     => "echo \$NET_PASSWORD | net ads join -U '${adminuser}' ${no_dns_updates} ${ou}",
         notify      => Service['SambaWinBind'],
         require     => Package['SambaClassic'],
       }

--- a/manifests/dc.pp
+++ b/manifests/dc.pp
@@ -57,6 +57,9 @@ class samba::dc(
   $netlogonabsentoptions                                          = [],
   $sysvolabsentoptions                                            = [],
   Optional[String] $cleanup                                       = undef,
+  $packagesambawinbind                                            = $::samba::params::packagesambawinbind,
+  $packagesambaclient                                             = $::samba::params::packagesambaclient,
+  $packagesambadc                                                 = $::samba::params::packagesambadc,
 ) inherits ::samba::params{
 
   case $dnsbackend {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,26 +8,14 @@ class samba::params(
   }else{
     case $facts['os']['family'] {
       'redhat': {
-          case $facts['os']['release']['major'] {
-              '6': {
-                  $packagesambadc         = 'samba4-dc'
-                  $packagesambaclassic    = 'samba4'
-                  $packagesambawinbind    = 'samba4-winbind'
-                  $packagesambansswinbind = 'samba4-winbind-clients'
-                  $packagesambapamwinbind = 'samba4-winbind-clients'
-                  $packagesambaclient     = 'samba4-client'
-              }
-              default: {
-                  $packagesambadc         = 'samba-dc'
-                  $packagesambaclassic    = 'samba'
-                  $packagesambawinbind    = 'samba-winbind'
-                  $packagesambansswinbind = 'samba-winbind-clients'
-                  $packagesambapamwinbind = 'samba-winbind-clients'
-                  $packagesambaclient     = 'samba-client'
-              }
-          }
           $cleanup                = undef
           # for now, this is not supported by RedHat
+          $packagesambadc         = 'samba-dc'
+          $packagesambaclassic    = 'samba'
+          $packagesambawinbind    = 'samba-winbind'
+          $packagesambansswinbind = 'samba-winbind-clients'
+          $packagesambapamwinbind = 'samba-winbind-clients'
+          $packagesambaclient     = 'samba-client'
           $servivesambadc         = undef
           $servivesmb             = 'smb'
           $servivewinbind         = 'winbind'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,14 +8,26 @@ class samba::params(
   }else{
     case $facts['os']['family'] {
       'redhat': {
+          case $facts['os']['release']['major'] {
+              '6': {
+                  $packagesambadc         = 'samba4-dc'
+                  $packagesambaclassic    = 'samba4'
+                  $packagesambawinbind    = 'samba4-winbind'
+                  $packagesambansswinbind = 'samba4-winbind-clients'
+                  $packagesambapamwinbind = 'samba4-winbind-clients'
+                  $packagesambaclient     = 'samba4-client'
+              }
+              default: {
+                  $packagesambadc         = 'samba-dc'
+                  $packagesambaclassic    = 'samba'
+                  $packagesambawinbind    = 'samba-winbind'
+                  $packagesambansswinbind = 'samba-winbind-clients'
+                  $packagesambapamwinbind = 'samba-winbind-clients'
+                  $packagesambaclient     = 'samba-client'
+              }
+          }
           $cleanup                = undef
-          $packagesambadc         = 'samba-dc'
-          $packagesambaclassic    = 'samba'
-          $packagesambawinbind    = 'samba-winbind'
-          $packagesambansswinbind = 'samba-winbind-clients'
-          $packagesambapamwinbind = 'samba-winbind-clients'
-          $packagesambaclient     = 'samba-client'
-          # for now, this is not supported by Debian
+          # for now, this is not supported by RedHat
           $servivesambadc         = undef
           $servivesmb             = 'smb'
           $servivewinbind         = 'winbind'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "kakwa-samba",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "kakwa",
   "summary": "Module managing Samba, including Samba as a AD Domain Controller",
   "license": "MIT",
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "herculesteam-augeasproviders_pam",
@@ -22,39 +22,35 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "8"
       ]
     },
     {
-      "operatingsystem": "CentOS",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "8"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04"
+        "20.04",
+        "22.04",
+        "24.04"
       ]
-    },
-    {
-      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
CentOS 6 has samba4-* packages, but rather than adding explicit support for these packages it is more flexible to allow changing of the package names from the default versions.
(If you have the samba-* default packages installed for 3.x on CentOS 6, then these conflict and so you need to forceably remove the old packages before installing these, which I wouldn't want to add to this module... :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/59)
<!-- Reviewable:end -->
