### PR TITLE
Remove duplicate content, add shares via parameter

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -57,12 +57,8 @@ class samba::classic(
   $joinou                         = undef,
   Optional[String] $default_realm = undef,
   Array $additional_realms        = [],
+  Optional[Array] $shares         = undef,
 ) inherits samba::params{
-
-
-  unless is_domain_name($realm){
-    fail('realm must be a valid domain')
-  }
 
   unless is_domain_name($realm){
     fail('realm must be a valid domain')
@@ -340,6 +336,8 @@ class samba::classic(
       }
     }
   }
+  
+  create_resources('samba::share', $shares)
 }
 
 # vim: tabstop=8 expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
- Removed duplicate validation of realm
- added parameter $shares, which allows to pass data via Hiera/ENC to create samba::share ressources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/62)
<!-- Reviewable:end -->
