### PR TITLE
Update and fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ script: "bundle exec rake validate && bundle exec rake lint || bundle exec rake 
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.5.3
+    env: PUPPET_GEM_VERSION="~> 6.2.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.5.0"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 4.10.0"
-  - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 5.4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.5.3
-    env: PUPPET_VERSION="~> 6.2.0"
+    env: PUPPET_VERSION="6.2.0"
   - rvm: 2.4.1
-    env: PUPPET_VERSION="~> 5.5.0"
+    env: PUPPET_VERSION="5.5.0"
   - rvm: 2.1.5
-    env: PUPPET_VERSION="~> 4.10.0"
+    env: PUPPET_VERSION="4.10.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.5.3
-    env: PUPPET_GEM_VERSION="~> 6.2.0"
+    env: PUPPET_VERSION="~> 6.2.0"
   - rvm: 2.4.1
-    env: PUPPET_GEM_VERSION="~> 5.5.0"
+    env: PUPPET_VERSION="~> 5.5.0"
   - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 4.10.0"
+    env: PUPPET_VERSION="~> 4.10.0"


### PR DESCRIPTION
Added latest 6.x puppet version with latest supported ruby, 2.5.x
Updated to latest 5.x puppet and latest supported ruby, 2.4.x

Changed environment variable to match Gemfile usage so these versions are actually the versions tested

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/65)
<!-- Reviewable:end -->
