### PR TITLE
Update stdlib version requirements.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "herculesteam-augeasproviders_pam",


### PR DESCRIPTION
Fixes: #67 

I have used this module with version [`5.2.0`](https://github.com/puppetlabs/puppetlabs-stdlib/tree/5.2.0) of  [`stdlib`](https://forge.puppet.com/puppetlabs/stdlib) and found no problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/66)
<!-- Reviewable:end -->
