### PR TITLE
Add lmhosts support to samba::classic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.gem
 *.rbc
 /.config

--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -46,6 +46,7 @@ class samba::classic(
   $security                       = 'ads',
   $sambaloglevel                  = 1,
   $join_domain                    = true,
+  $manage_lmhosts                 = true,
   $manage_winbind                 = true,
   $krbconf                        = true,
   $nsswitch                       = true,
@@ -206,6 +207,10 @@ class samba::classic(
     name   => $samba::params::packagesambaclassic,
   }
 
+  if $manage_lmhosts {
+    include ::samba::lmhosts
+  }
+
   if $manage_winbind {
     package{ 'SambaClassicWinBind':
       ensure  => 'installed',
@@ -231,7 +236,7 @@ class samba::classic(
     }
   }
   $sambamode = 'classic'
-  # Deploy /etc/sysconfig/|/etc/defaut/ file (startup options)
+  # Deploy /etc/sysconfig/|/etc/default/ file (startup options)
   file{ 'SambaOptsFile':
     path    => $samba::params::sambaoptsfile,
     content => template($samba::params::sambaoptstmpl),

--- a/manifests/lmhosts.pp
+++ b/manifests/lmhosts.pp
@@ -1,0 +1,76 @@
+# @summary Manage the /etc/samba/lmhosts file.
+#
+# This class manages entries within the Samba lmhosts file, based on documentation
+# found at http://bit.ly/2L2zaYJ
+#
+# @example
+#   class { 'samba::lmhosts' :
+#     list => [
+#       {
+#         'address' => '127.0.0.1',
+#         'host'    => 'localhost',
+#       },
+#       { 'address' => '192.168.1.100',
+#         'host'    => 'pdc',
+#       }
+#     ],
+#
+# @param [Samba::Lmhosts::List] list
+#   Ordered List of lmhosts entries.
+#
+# @param [Boolean] no_export
+#   If true, do not export the current host for use by other nodes.
+#
+# @param [Boolean] no_import
+#   If true, do not add exported host entries to this node's lmhosts file.
+#
+# @param [Stdlib::Absolutepath] path
+#   Absolute path to the lmhosts file to manage.
+#
+class samba::lmhosts(
+  Samba::Lmhosts::List $list      = [
+    {
+      'address' => '127.0.0.1',
+      'host'    => 'localhost'
+    }
+  ],
+  Boolean              $no_export = false,
+  Boolean              $no_import = false,
+  Stdlib::Absolutepath $path      = [
+    '/etc/samba/lmhosts',
+    "${facts['windows_env']['SYSTEMROOT']}\\System32\\drivers\\etc\\lmhosts"
+  ][$facts['kernel'] ? { 'windows' => 1, default => 0 }]
+){
+  # Create the lmhosts file.
+  concat { $path:
+    ensure => 'present',
+  }
+
+  # Add static hosts not in the catalog.
+  $list.each |Integer[0,9999] $index, Samba::Lmhosts::Entry $entry| {
+    $type = $entry ? {
+      Samba::Lmhosts::Alternates::Resource => 'samba::lmhosts::alternates',
+      Samba::Lmhosts::Host::Resource       => 'samba::lmhosts::host',
+      Samba::Lmhosts::Include::Resource    => 'samba::lmhosts::include',
+    }
+    $order = String($index, '%04d')
+    create_resources($type, { "${path} ${order}" => $entry })
+  }
+
+  # Export the current host.
+  unless $no_export {
+    $hostname = $facts['networking']['hostname']
+    @@samba::lmhosts::host { "${path} ${hostname} (exported)":
+      address => $facts['networking']['ip'],
+      host    => $hostname,
+      index   => 'catalog',
+      path    => $path,
+      preload => true,
+    }
+  }
+
+  # Collect all exported hosts.
+  unless $no_import {
+    Samba::Lmhosts::Host <<| |>>
+  }
+}

--- a/manifests/lmhosts/alternates.pp
+++ b/manifests/lmhosts/alternates.pp
@@ -1,0 +1,47 @@
+# @summary Adds an alternates block to the lmhosts file.
+#
+# Samba will attempt to load each alternate file in turn, stopping at the first
+# available and ignoring the rest.
+#
+# @example
+#   samba::lmhosts::alternates { '/etc/lmhosts 1234':
+#     alternates => [
+#       '//pdc/share/lmhosts',
+#       '//bdc/share/lmhosts',
+#     ]
+#   }
+#
+# @param [Array[Samba::Lmhosts::Include_path::Path]] alternates
+#   The list of local or UNC file paths to load.
+#
+# @param [Samba::Lmhosts::Order] index
+#   Used by stdlib::concat to assemble lmhosts fragments in the correct order.
+#
+# @param [Stdlib::Absolutepath] path
+#   The file path of the lmhosts file being managed.
+#
+define samba::lmhosts::alternates (
+  Array[Samba::Lmhosts::Include_path::Path] $alternates,
+  Samba::Lmhosts::Order                     $index = regsubst($title, /\A(.+)[ ]([0-9.]+)\z/, '\\2'),
+  Stdlib::Absolutepath                      $path  = regsubst($title, /\A(.+)[ ]([0-9.]+)\z/, '\\1'),
+) {
+  $order = $index ? {
+    Integer => String($index, '%04d'),
+    default => $index,
+  }
+  concat::fragment { "samba::lmhosts::alternate::begin ${title}":
+    content => "#BEGIN_ALTERNATE\r\n",
+    order   => "${order}.0000",
+    target  => $path,
+  }
+  $alternates.each |Integer[1] $subindex, Samba::Lmhosts::Include_path::Path $inc| {
+    $suborder = String($subindex, '%04d')
+    $subtitle = "${path} ${order}.${suborder}"
+    create_resources('samba::lmhosts::include_path', { $subtitle => { 'include_path' => $inc } })
+  }
+  concat::fragment { "lmhosts::alternate::end ${title}":
+    content => "#END_ALTERNATE\r\n",
+    order   => "${order}.9999",
+    target  => $path,
+  }
+}

--- a/manifests/lmhosts/host.pp
+++ b/manifests/lmhosts/host.pp
@@ -1,0 +1,74 @@
+# @summary Add a host entry to the lmhosts file.
+#
+# A host entry consists of an IPv4 address, an smb netbios name, and some
+# optional flags.
+#
+# @example
+#   samba::lmhosts::host { '/etc/lmhosts localhost':
+#     address: '127.0.0.1',
+#     preload: true,
+#   }
+#
+# @param [Stdlib::IP::Address::V4::Nosubnet] address
+#   The IPv4 address of this host entry.
+#
+# @param [Enum['absent','present']] ensure
+#   Whether to remove ('absent') or add ('present') this host entry.
+#
+# @param [Optional[Samba::Lmhosts::Host::Name]] domain
+#   The Samba domain to which this host will be added, if diferent from the
+#   default domain.
+#
+# @param [Samba::Lmhosts::Host::Name] host
+#   The netbios name of this computer or service.
+#
+# @param [Optional[Samba::Lmhosts::Order]] index
+#   Used by the concat module to assemble the lmhosts file from parts.
+#
+# @param [Boolean] multiple
+#   If true, this is one of up to 25 entries for the same host.
+#
+# @param [Stdlib::Absolutepath] path
+#   The location of the lmhosts file.
+#
+# @param [Boolean] preload
+#   If true (default), this entry should be preloaded into cache.
+#
+# @param [Optional[Integer[0x00,0xff]]] service
+#   An optional integer service code.  See $samba::lmhosts::host::service
+#
+define samba::lmhosts::host (
+  Stdlib::IP::Address::V4::Nosubnet        $address,
+  Enum['absent','present']                 $ensure   = 'present',
+  Optional[Samba::Lmhosts::Host::Name]     $domain   = undef,
+  Samba::Lmhosts::Host::Name               $host     = regsubst($title, /\A(.+)[ ]([^\\\/:*?"<>|]{1,15})\z/, '\\2'),
+  Optional[Samba::Lmhosts::Order]          $index    = undef,
+  Boolean                                  $multiple = false,
+  Stdlib::Absolutepath                     $path     = regsubst($title, /\A(.+)[ ]([^\\\/:*?"<>|]{1,15})\z/, '\\1'),
+  Boolean                                  $preload  = true,
+  Optional[Integer[0x00,0xff]]             $service  = undef,
+) {
+  $_address = sprintf('%-15s', $address)
+  $_domain = $domain ? {
+    undef   => '',
+    default => " #DOM:${domain}"
+  }
+  $_host = $service ? {
+    undef   => sprintf('%-22s', $host),
+    default => sprintf('"%-15s\\0x%2x"', $host, $service),
+  }
+  $_multiple = $multiple? {
+    false   => '',
+    default => ' #MH',
+  }
+  $_preload = $preload ? {
+    false   => '',
+    default => ' #PRE',
+  }
+  $_content = strip("${_address} ${_host}${_multiple}${_preload}")
+  concat::fragment { "samba::lmhosts::host ${title}":
+    content => "${_content}\r\n",
+    order   => $index,
+    target  => $path,
+  }
+}

--- a/manifests/lmhosts/include_path.pp
+++ b/manifests/lmhosts/include_path.pp
@@ -1,0 +1,35 @@
+# @summary Add an #INCLUDE path to the lmhosts file.
+#
+# If the order and path are unspecified, the title must
+# consist of a filepath followed by a space and a valid
+# order string.
+#
+# @example
+#   samba::lmhosts::include_path { '/etc/lmhosts 1234':
+#     include_path => '//pdc/share/lmhosts',
+#   }
+#
+# @param [Samba::Lmhosts::Include_path::Path] include_path
+#   Local path or UNC of the lmhosts fragment to include.
+#
+# @param [Samba::Lmhosts::Order] index
+#   Used by stdlib::concat to assemble lmhosts fragments in the correct order.
+#
+# @param [Stdlib::Absolutepath] path
+#   The file path of the lmhosts file being managed.
+#
+define samba::lmhosts::include_path (
+  Samba::Lmhosts::Include_path::Path $include_path,
+  Samba::Lmhosts::Order              $index = regsubst($title, /\A(.+)[ ]([0-9.]+)\z/, '\\2'),
+  Stdlib::Absolutepath               $path  = regsubst($title, /\A(.+)[ ]([0-9.]+)\z/, '\\1'),
+) {
+  $order = $index ? {
+    Integer => String($index, '%04d'),
+    default => $index,
+  }
+  concat::fragment { "samba::lmhosts::include_path ${title}":
+    content => "#INCLUDE ${include_path}\r\n",
+    order   => $order,
+    target  => $path,
+  }
+}

--- a/types/lmhosts/alternates/resource.pp
+++ b/types/lmhosts/alternates/resource.pp
@@ -1,0 +1,10 @@
+# @summary
+#   Ordered List of alternate file or UNC locations where Lmhosts fragments may be found.
+#
+type Samba::Lmhosts::Alternates::Resource = Struct[
+  {
+    alternates      => Array[Samba::Lmhosts::Include_path::Path],
+    Optional[index] => Samba::Lmhosts::Order,
+    Optional[path]  => Stdlib::Absolutepath,
+  }
+]

--- a/types/lmhosts/entry.pp
+++ b/types/lmhosts/entry.pp
@@ -1,0 +1,8 @@
+# @summary
+#   An LMhosts entry may be a host, an include, or a list of alternates.
+#
+type Samba::Lmhosts::Entry = Variant[
+  Samba::Lmhosts::Alternates::Resource,
+  Samba::Lmhosts::Host::Resource,
+  Samba::Lmhosts::Include_path::Resource,
+]

--- a/types/lmhosts/host/filesource.pp
+++ b/types/lmhosts/host/filesource.pp
@@ -1,0 +1,7 @@
+# @summary
+#   A local or remote file path.
+#
+type Samba::Lmhosts::Host::Filesource = Variant[
+  Samba::Lmhosts::UNC,
+  Stdlib::Absolutepath,
+]

--- a/types/lmhosts/host/include.pp
+++ b/types/lmhosts/host/include.pp
@@ -1,0 +1,7 @@
+# @summary
+#   One more more files or UNC paths.
+#
+type Samba::Lmhosts::Host::Include = Variant[
+  Array[Samba::Lmhosts::Host::Filesource,2]
+  Samba::Lmhosts::Host::Filesource,
+]

--- a/types/lmhosts/host/name.pp
+++ b/types/lmhosts/host/name.pp
@@ -1,0 +1,16 @@
+# @summary
+#   A Netbios hostname may be up to 15 characters long. Due to DNS restrictions,
+#   it may not be composed entirely of numbers.  It may contain any character
+#   except for the following:
+#   * backslash (\)
+#   * slash mark (/)
+#   * colon (:)
+#   * asterisk (*)
+#   * question mark (?)
+#   * quotation mark (")
+#   * less than sign (<)
+#   * greater than sign (>)
+#   * vertical bar (|)
+#   * period (.) -- Windows 2000 and later only.
+#
+type Samba::Lmhosts::Host::Name = Pattern[/\A[^\\\/:*?"<>|]{1,15}\z/]

--- a/types/lmhosts/host/resource.pp
+++ b/types/lmhosts/host/resource.pp
@@ -1,0 +1,17 @@
+# @summary
+#   Struct of lmhosts::host attributes suitable for passing as the third parameter
+#   to ensure_resource().
+#
+type Lmhosts::Host::Resource = Struct[
+  {
+    address            => Stdlib::IP::Address::V4::Nosubnet,
+    Optional[ensure]   => Enum['absent','present'],
+    Optional[domain]   => Samba::Lmhosts::Host::Name,
+    Optional[host]     => Samba::Lmhosts::Host::Name,
+    Optional[index]    => Integer[1],
+    Optional[multiple] => Boolean,
+    Optional[path]     => Stdlib::Absolutepath,
+    Optional[preload]  => Boolean,
+    Optional[service]  => Integer[0x00,0xff],
+  }
+]

--- a/types/lmhosts/include_path/path.pp
+++ b/types/lmhosts/include_path/path.pp
@@ -1,0 +1,7 @@
+# @summary
+#   An include path can either a local file path or a UNC path.
+#
+type Samba::Lmhosts::Include_path::Path = Variant[
+  Stdlib::Absolutepath,
+  Samba::Lmhosts::UNC,
+]

--- a/types/lmhosts/include_path/resource.pp
+++ b/types/lmhosts/include_path/resource.pp
@@ -1,0 +1,10 @@
+# @summary
+#   An include contains either a local file path or a UNC path.
+#
+type Samba::Lmhosts::Include_path::Resource = Struct[
+  {
+    include_path    => Samba::Lmhosts::Include_path::Path,
+    Optional[index] => Samba::Lmhosts::Order,
+    Optional[path]  => Stdlib::Absolutepath,
+  }
+]

--- a/types/lmhosts/list.pp
+++ b/types/lmhosts/list.pp
@@ -1,0 +1,4 @@
+# @summary
+#   Array of samba::lmhosts::entry
+#
+type Samba::Lmhosts::List = Array[Samba::Lmhosts::Entry]

--- a/types/lmhosts/order.pp
+++ b/types/lmhosts/order.pp
@@ -1,0 +1,9 @@
+# @summary
+#   Used by concat to assemble parts of the lmhosts file in the correct order.
+#
+type Samba::Lmhosts::Order = Variant[
+  Enum['catalog'],
+  Integer[0,9999],
+  Pattern[/\A[0-9]{4}\z/],
+  Pattern[/\A[0-9]{4}[.][0-9]{4}\z/],
+]

--- a/types/lmhosts/unc.pp
+++ b/types/lmhosts/unc.pp
@@ -1,0 +1,13 @@
+# @summary
+#   Universal Naming Convention: http://bit.ly/2ZDzmBd
+#
+type Samba::Lmhosts::UNC = Struct[
+  {
+    host             => Stdlib::Host,
+    share            => Pattern[/\A[^\x00-\x1f\x22\x2a-\x2c\x2f\x3a-\x3f\x5b-\x5d\x7c]{1,80}\z/],
+    path             => Pattern[/\A[^\x00-\x19\x22\x2a-\x2c\x2f\x3a-\x3f\x5b-\x5d\x7c]{1,255}\z/],
+    Optional[file]   => Pattern[/\A[^\x00-\x1f\x22\x2a\x2f\x2a\x3c\x3e\x2f\x5c\x7c]{1,255}\z/],
+    Optional[stream] => Pattern[/\A[\x00\x2f\x3a\x5c]*\z/],
+    Optional[stype]  => Pattern[/\A[\x00\x2f\x3a\x5c]\z/],
+  }
+]


### PR DESCRIPTION
Adds inventoried hosts to `/etc/samba/lmhosts` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/68)
<!-- Reviewable:end -->
