### PR TITLE
standalone mode - allows samba setup without requiring a realm, or other unnecessary dependencies

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -264,7 +264,7 @@ unless $standalonemode {
       'map acl inherit'                    => 'No',
       'store dos attributes'               => 'Yes',
       'map untrusted to domain'            => 'No ',
-    }    
+    }
   }
   else {
     $mandatoryglobaloptions = {


### PR DESCRIPTION
Create a mode to allow for a standalone samba server 
- no id mapping
- no kerberos, winbind
- an even more classic classic mode
- should be used with security = user

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/70)
<!-- Reviewable:end -->
