### PR TITLE
Support Debian 10

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -217,7 +217,7 @@ class samba::classic(
 
   service{ 'SambaSmb':
     ensure  => 'running',
-    name    => $samba::params::servivesmb,
+    name    => $samba::params::servicesmb,
     require => [ Package['SambaClassic'], File['SambaOptsFile'] ],
     enable  => true,
   }
@@ -225,7 +225,7 @@ class samba::classic(
   if $manage_winbind {
     service{ 'SambaWinBind':
       ensure  => 'running',
-      name    => $samba::params::servivewinbind,
+      name    => $samba::params::servicewinbind,
       require => [ Package['SambaClassic'], File['SambaOptsFile'] ],
       enable  => true,
     }

--- a/manifests/dc.pp
+++ b/manifests/dc.pp
@@ -175,7 +175,7 @@ ex: domain="ad" and realm="ad.example.com"')
 
   service{ 'SambaClassic':
     ensure  => 'stopped',
-    name    => $::samba::params::servivesmb,
+    name    => $::samba::params::servicesmb,
     enable  => false,
     require => Package['SambaDC'],
     notify  => Service['SambaDC'],
@@ -211,7 +211,7 @@ mv '${targetdir}/etc/smb.conf' '${::samba::params::smbconffile}'",
 
   service{ 'SambaDC':
     ensure  => 'running',
-    name    => $::samba::params::servivesambadc,
+    name    => $::samba::params::servicesambadc,
     require => [ Exec['provisionAD'], File['SambaOptsFile'] ],
     enable  => true,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,9 +16,9 @@ class samba::params(
           $packagesambapamwinbind = 'samba-winbind-clients'
           $packagesambaclient     = 'samba-client'
           # for now, this is not supported by Debian
-          $servivesambadc         = undef
-          $servivesmb             = 'smb'
-          $servivewinbind         = 'winbind'
+          $servicesambadc         = undef
+          $servicesmb             = 'smb'
+          $servicewinbind         = 'winbind'
           $sambacmd               = '/usr/bin/samba-tool'
           $sambaclientcmd         = '/usr/bin/smbclient'
           $sambaoptsfile          = '/etc/sysconfig/samba'
@@ -35,15 +35,15 @@ class samba::params(
           $packagesambansswinbind = 'libnss-winbind'
           $packagesambapamwinbind = 'libpam-winbind'
           $packagesambaclient     = 'smbclient'
-          $servivesambadc         = 'samba-ad-dc'
+          $servicesambadc         = 'samba-ad-dc'
           if $facts['os']['name'] == 'Ubuntu' {
-            $servivesmb           = 'smbd'
-          } elsif ($facts['os']['name'] == 'Debian') and ($facts['os']['release']['major'] >= '8') {
-            $servivesmb           = 'smbd'
+            $servicesmb           = 'smbd'
+          } elsif ($facts['os']['name'] == 'Debian') and (versioncmp($facts['os']['release']['full'], '8') >= 0) {
+            $servicesmb           = 'smbd'
           } else {
-            $servivesmb           = 'samba'
+            $servicesmb           = 'samba'
           }
-          $servivewinbind         = 'winbind'
+          $servicewinbind         = 'winbind'
           $sambacmd               = '/usr/bin/samba-tool'
           $sambaclientcmd         = '/usr/bin/smbclient'
           $sambaoptsfile          = '/etc/default/samba4'
@@ -60,9 +60,9 @@ class samba::params(
           $packagesambansswinbind = 'libnss-winbind'
           $packagesambapamwinbind = 'libpam-winbind'
           $packagesambaclient     = 'smbclient'
-          $servivesambadc         = 'samba'
-          $servivesmb             = 'smbd'
-          $servivewinbind         = 'winbindd'
+          $servicesambadc         = 'samba'
+          $servicesmb             = 'smbd'
+          $servicewinbind         = 'winbindd'
           $sambacmd               = '/usr/bin/samba-tool'
           $sambaclientcmd         = '/usr/bin/smbclient'
           $sambaoptsfile          = '/etc/default/samba4'


### PR DESCRIPTION
Hi,

thanks for your great module!

On Debian 10, it fails to start the SMB service: in the params.pp, the string comparison of "10" vs "8" fails, so the wrong service name is picked.

Changes:
* use versioncmp() to actually support Debian 10
* unified parameter name to international version (my french is not the best, so I'm uncertain if this was a very consequent typo, or intentional. the parameter now matches the service resource.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/71)
<!-- Reviewable:end -->
