### PR TITLE
Updated dependency requirements to modern stdlib, puppet and ubuntu versions

### DIFF
--- a/manifests/classic.pp
+++ b/manifests/classic.pp
@@ -37,7 +37,7 @@
 #
 
 class samba::classic(
-  $smbname                        = undef,
+  String[1,15] $smbname           = undef,
   $domain                         = undef,
   $realm                          = undef,
   $strictrealm                    = true,
@@ -68,7 +68,6 @@ class samba::classic(
     fail('realm must be a valid domain')
   }
 
-  validate_slength($smbname, 15)
   unless is_domain_name("${smbname}.${realm}"){
     fail('smbname must be a valid domain')
   }

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "herculesteam-augeasproviders_pam",
@@ -44,7 +44,9 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     },
     {
@@ -54,7 +56,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
This updates the dependency requirements to support modern state of puppet, stdlib and ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/72)
<!-- Reviewable:end -->
