### PR TITLE
exists function has been removed in Ruby 3.2.0

### DIFF
--- a/lib/facter/samba_version.rb
+++ b/lib/facter/samba_version.rb
@@ -8,11 +8,11 @@ distid = Facter.value(:operatingsystem)
 
 case distid
     when /RedHatEnterprise|CentOS|Fedora|RHEL/
-        if  FileTest.exists?("/usr/bin/yum")
+        if  FileTest.exist?("/usr/bin/yum")
             version = Facter::Util::Resolution.exec('/usr/bin/yum info samba | sed \'s/Version *: \([0-9\.]\+\)/\1/gp;d\' | head -n 1')
         end
     when /Ubuntu|Debian/
-        if  FileTest.exists?("/usr/bin/apt-cache")
+        if  FileTest.exist?("/usr/bin/apt-cache")
             version = Facter::Util::Resolution.exec('apt-cache show samba | sed \'s/Version:.*:\([0-9\.]\+\).*/\1/gp;d\' | head -n 1')
         end
     when 'Archlinux'
@@ -29,4 +29,3 @@ Facter.add("samba_version") do
         version
     end
 end
-


### PR DESCRIPTION
See https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakwa/puppet-samba/78)
<!-- Reviewable:end -->
